### PR TITLE
Dev

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,25 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(gh issue:*)",
+      "WebFetch(domain:chatgpt.com)",
+      "WebFetch(domain:www.nuget.org)",
+      "Bash(dotnet sln:*)",
+      "Bash(dotnet build:*)",
+      "Bash(grep:*)",
+      "Bash(ls:*)",
+      "Bash(dotnet pack:*)",
+      "Bash(dotnet tool:*)",
+      "Bash(bash:*)",
+      "Bash(do:*)",
+      "Bash(dotnet trash:*)",
+      "Bash(unzip:*)",
+      "Bash(git add:*)",
+      "Bash(git commit:*)",
+      "Bash(git config:*)",
+      "Bash(sed:*)",
+      "Bash(sed s|.*:||:*)",
+      "Bash(git push:*)"
+    ]
+  }
+}

--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "trash": {
-      "version": "1.0.0",
+      "version": "1.1.0",
       "commands": [
         "trash"
       ],

--- a/_scripts/publish.sh
+++ b/_scripts/publish.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/bash
-version=1.0.0
+version=1.1.0
 cd src
 dotnet nuget push trash/bin/Release/trash.$version.nupkg --api-key $trashkey --source https://api.nuget.org/v3/index.json

--- a/_scripts/set-version.sh
+++ b/_scripts/set-version.sh
@@ -42,7 +42,7 @@ do
 	do
 		sed -i -e "s%[<][Vv]ersion[>].*[<][/][Vv]ersion[>]%<Version\>$version</Version>%" $csproj
 	done
-        sed -i -e 's%^[0-9]*[.][0-9]*[.][0-9]*.*$'"%$version"' Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github.%' readme.md
+        sed -i -e 's%^[0-9]*[.][0-9]*[.][0-9]*.*$'"%$version"' Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github. Add tokens per second perf measurement.%' readme.md
 	for cs in *.cs
 	do
 		sed -i -e "s%public string Version { get; set; } = \"[0-9][.][0-9]*[.][0-9]*\";%public string Version { get; set; } = \"$version\";%" $cs
@@ -80,7 +80,7 @@ do
         rm -f asdfasdf
         cat *.csproj | sed -e "s%[<][Vv]ersion[>].*[<][/][Vv]ersion[>]%<Version\>$version</Version>%" > asdfasdf
         mv asdfasdf *.csproj    
-        sed -i -e 's%^[0-9]*[.][0-9]*[.][0-9]*.*$'"%$version"' Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github.%' readme.md
+        sed -i -e 's%^[0-9]*[.][0-9]*[.][0-9]*.*$'"%$version"' Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github. Add tokens per second perf measurement.%' readme.md
         cd ..
 done
 

--- a/_scripts/set-version.sh
+++ b/_scripts/set-version.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/bash
 #set -e
 #set -x
-version="1.0.0"
+version="1.1.0"
 cd src
 directories=`find . -maxdepth 1 -type d -name "tr*"`
 cwd=`pwd`
@@ -42,7 +42,7 @@ do
 	do
 		sed -i -e "s%[<][Vv]ersion[>].*[<][/][Vv]ersion[>]%<Version\>$version</Version>%" $csproj
 	done
-        sed -i -e 's%^0[.][0-9]*[.][0-9]*.*$'"%$version"' Unified dispatcher for the Trash toolkit.%' readme.md
+        sed -i -e 's%^0[.][0-9]*[.][0-9]*.*$'"%$version"' Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github.%' readme.md
 	for cs in *.cs
 	do
 		sed -i -e "s%public string Version { get; set; } = \"0[.][0-9]*[.][0-9]*\";%public string Version { get; set; } = \"$version\";%" $cs
@@ -80,7 +80,7 @@ do
         rm -f asdfasdf
         cat *.csproj | sed -e "s%[<][Vv]ersion[>].*[<][/][Vv]ersion[>]%<Version\>$version</Version>%" > asdfasdf
         mv asdfasdf *.csproj    
-        sed -i -e 's%^0[.][0-9]*[.][0-9]*.*$'"%$version"' Unified dispatcher for the Trash toolkit.%' readme.md
+        sed -i -e 's%^0[.][0-9]*[.][0-9]*.*$'"%$version"' Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github.%' readme.md
         cd ..
 done
 

--- a/_scripts/set-version.sh
+++ b/_scripts/set-version.sh
@@ -42,10 +42,10 @@ do
 	do
 		sed -i -e "s%[<][Vv]ersion[>].*[<][/][Vv]ersion[>]%<Version\>$version</Version>%" $csproj
 	done
-        sed -i -e 's%^0[.][0-9]*[.][0-9]*.*$'"%$version"' Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github.%' readme.md
+        sed -i -e 's%^[0-9]*[.][0-9]*[.][0-9]*.*$'"%$version"' Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github.%' readme.md
 	for cs in *.cs
 	do
-		sed -i -e "s%public string Version { get; set; } = \"0[.][0-9]*[.][0-9]*\";%public string Version { get; set; } = \"$version\";%" $cs
+		sed -i -e "s%public string Version { get; set; } = \"[0-9][.][0-9]*[.][0-9]*\";%public string Version { get; set; } = \"$version\";%" $cs
 	done
         cd ..
 done
@@ -80,7 +80,7 @@ do
         rm -f asdfasdf
         cat *.csproj | sed -e "s%[<][Vv]ersion[>].*[<][/][Vv]ersion[>]%<Version\>$version</Version>%" > asdfasdf
         mv asdfasdf *.csproj    
-        sed -i -e 's%^0[.][0-9]*[.][0-9]*.*$'"%$version"' Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github.%' readme.md
+        sed -i -e 's%^[0-9]*[.][0-9]*[.][0-9]*.*$'"%$version"' Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github.%' readme.md
         cd ..
 done
 

--- a/_tests/basic-trees/test.sh
+++ b/_tests/basic-trees/test.sh
@@ -12,12 +12,12 @@ echo "$where"
 
 # Test.
 rm -rf Generated-CSharp
-dotnet trash gen --version
-dotnet trash gen -t CSharp
+trash gen --version
+trash gen -t CSharp
 pushd Generated-CSharp
 make
 popd
-echo "1 + 2 + 3" | dotnet trash parse | dotnet trash tree > trparse.tree
+echo "1 + 2 + 3" | trash parse | trash tree > trparse.tree
 rm -rf Generated-CSharp
 
 # Diff result.

--- a/_tests/basic-trees/test.sh
+++ b/_tests/basic-trees/test.sh
@@ -12,12 +12,12 @@ echo "$where"
 
 # Test.
 rm -rf Generated-CSharp
-trash gen --version
-trash gen -t CSharp
+dotnet trash gen --version
+dotnet trash gen -t CSharp
 pushd Generated-CSharp
 make
 popd
-echo "1 + 2 + 3" | trash parse | trash tree > trparse.tree
+echo "1 + 2 + 3" | dotnet trash parse | dotnet trash tree > trparse.tree
 rm -rf Generated-CSharp
 
 # Diff result.

--- a/readme.md
+++ b/readme.md
@@ -171,7 +171,7 @@ In order to use the generate parser application, you must first build it:
 
 ### Run the generated parser application
 
-    dotnet trash parse -i "1+2+3" | dotnet trash tree
+    trash parse -i "1+2+3" | trash tree
 
 After using `trgen` to generate a parser program in C#, shown previously,
 and after building the program, you can run the parser using `trparse`. This program 
@@ -183,14 +183,14 @@ with most tools of Trash, is parse tree data.
 
 ### Find nodes in the parse tree using XPath
 
-    mkdir empty; cd empty; dotnet trash gen; dotnet build Generated/Test.csproj; \
-        dotnet trash parse -i "1+2+3" | dotnet trash query "grep //SCIENTIFIC_NUMBER" | trst
+    mkdir empty; cd empty; trash gen; dotnet build Generated/Test.csproj; \
+        trash parse -i "1+2+3" | trash query "grep //SCIENTIFIC_NUMBER"
 
 With this command, a directory is created, the Arithmetic grammar generated, build,
-and then run using [trparse](https://github.com/kaby76/Trash/tree/main/src/trparse).
-The `trparse` tool unifies all parsing, whether it's parsing a grammar or parsing input
+and then run using [parse](https://github.com/kaby76/Trash/tree/main/src/trparse).
+The `trash parse` tool unifies all parsing, whether it's parsing a grammar or parsing input
 using a generated parser application. The output from the `trparse` tool is a parse
-tree which you can search. [Trquery](https://github.com/kaby76/Trash/tree/main/src/trquery)
+tree which you can search. [query](https://github.com/kaby76/Trash/tree/main/src/trquery)
 is the generalized search program for parse trees. `Trquery` uses XPath expressions to
 precisely identify nodes in the parse tree.
 
@@ -202,8 +202,8 @@ used more often in compiler construction.
 
 ### Rename a symbol in a grammar, generate a parser for new grammar
 
-    dotnet trash parse Arithmetic.g4 | dotnet trash rename "//parserRuleSpec//labeledAlt//RULE_REF[text() = 'expression']" "xxx" | dotnet trash text > new-source.g4
-    dotnet trash parse Arithmetic.g4 | dotnet trash rename -r "expression,expression_;atom,atom_;scientific,scientific_" | trprint
+    trash parse Arithmetic.g4 | trash rename "//parserRuleSpec//labeledAlt//RULE_REF[text() = 'expression']" "xxx" | dotnet trash text > new-source.g4
+    trash parse Arithmetic.g4 | trash rename -r "expression,expression_;atom,atom_;scientific,scientific_" | trprint
 
 In these two examples, the Arithmetic grammar is parsed.
 [trrename](https://github.com/kaby76/Trash/tree/main/src/trrename) reads the parse tree data and
@@ -217,8 +217,8 @@ grammar symbols in any support source code (but it could if the tool is extended
 
     git clone https://github.com/antlr/grammars-v4.git; \
         cd grammars-v4/java/java9; \
-        dotnet trash gen; dotnet build Generated/Test.csproj;\
-        dotnet trash parse examples/AllInOne8.java | dotnet trash query "greap //methodDeclaration" | trst | wc
+        trash gen; dotnet build Generated/Test.csproj;\
+        trash parse examples/AllInOne8.java | trash query "greap //methodDeclaration" | trst | wc
 
 This command clones the Antlr4 grammars-v4 repo, generates a parser for the Java9 grammar,
 then runs the parser on [examples/AllInOne8.java](https://github.com/antlr/grammars-v4/blob/master/java/java9/examples/AllInOne8.java).
@@ -228,7 +228,7 @@ a `methodDeclaration` type, converts it to a simple string, and counts the resul
 
 ### Strip a grammar of all non-essential CFG
 
-    dotnet trash parse Java9.g4 | trstrip | dotnet trash text > Essential-Java9.g4
+    trash parse Java9.g4 | trash strip | trash text > Essential-Java9.g4
 
 ### Split a grammar
 
@@ -239,7 +239,7 @@ a grammar, it's tedious. For automating transformations, it's
 necessary because Antlr4 requires the grammars to be split
 when super classes are needed for different targets.
 
-    dotnet trash combine ArithmeticLexer.g4 ArithmeticParser.g4 | trprint > Arithmetic.g4
+    trash combine ArithmeticLexer.g4 ArithmeticParser.g4 | trash text > Arithmetic.g4
 
 This command calls [trcombine](https://github.com/kaby76/Trash/tree/main/src/trcombine)
 which parses two split grammar files
@@ -249,7 +249,7 @@ and
 and creates a [combined grammar](https://github.com/kaby76/Trash/blob/main/_tests/combine/Arithmetic.g4)
 for the two.
 
-    dotnet trash parse Arithmetic.g4 | dotnet trash split | dotnet trash sponge -o true
+    trash parse Arithmetic.g4 | trash split | trash sponge -o true
 
 This command calls [trsplit](https://github.com/kaby76/Trash/tree/main/src/trsplit)
 which splits the grammar into two parse tree results, one that defines

--- a/src/tragl/readme.md
+++ b/src/tragl/readme.md
@@ -19,7 +19,7 @@ This tool is part of Trash, Transformations for Antlr Shell.
 
 ## Current version
 
-1.0.0 Unified dispatcher for the Trash toolkit.
+1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github.
 
 ## License
 

--- a/src/tragl/readme.md
+++ b/src/tragl/readme.md
@@ -19,7 +19,7 @@ This tool is part of Trash, Transformations for Antlr Shell.
 
 ## Current version
 
-1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github.
+1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github. Add tokens per second perf measurement.
 
 ## License
 

--- a/src/tragl/tragl.csproj
+++ b/src/tragl/tragl.csproj
@@ -20,7 +20,7 @@ This program is part of the Trash toolkit.]]>
 		<PublishRepositoryUrl>true</PublishRepositoryUrl>
 		<DebugType>portable</DebugType>
 		<DebugSymbols>true</DebugSymbols>
-		<Version>1.0.0</Version>
+		<Version>1.1.0</Version>
 		<RepositoryUrl>https://github.com/kaby76/Trash/tree/main/src/tragl</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
 	</PropertyGroup>

--- a/src/tranalyze/Config.cs
+++ b/src/tranalyze/Config.cs
@@ -18,6 +18,6 @@ namespace tranalyze
         public bool Verbose { get; set; }
 
 	[Option("version", Required = false)]
-	public string Version { get; set; } = "1.0.0";
+	public string Version { get; set; } = "1.1.0";
     }
 }

--- a/src/tranalyze/readme.md
+++ b/src/tranalyze/readme.md
@@ -65,7 +65,7 @@ _Output_
 
 ## Current version
 
-1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github.
+1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github. Add tokens per second perf measurement.
 
 ## License
 

--- a/src/tranalyze/readme.md
+++ b/src/tranalyze/readme.md
@@ -65,7 +65,7 @@ _Output_
 
 ## Current version
 
-1.0.0 Unified dispatcher for the Trash toolkit.
+1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github.
 
 ## License
 

--- a/src/tranalyze/tranalyze.csproj
+++ b/src/tranalyze/tranalyze.csproj
@@ -18,7 +18,7 @@ This program is part of the Trash toolkit.]]>
 		<PublishRepositoryUrl>true</PublishRepositoryUrl>
 		<DebugType>portable</DebugType>
 		<DebugSymbols>true</DebugSymbols>
-		<Version>1.0.0</Version>
+		<Version>1.1.0</Version>
 		<RepositoryUrl>https://github.com/kaby76/Trash/tree/main/src/tranalyze</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
 	</PropertyGroup>

--- a/src/trash/Program.cs
+++ b/src/trash/Program.cs
@@ -8,7 +8,7 @@ namespace Trash;
 
 public class Program
 {
-    private const string Version = "0.23.45";
+    private const string Version = "1.1.0";
 
     // Maps both full names (e.g. "trgen") and short aliases (e.g. "gen") to the
     // sub-tool directory name that lives next to trash.dll in the package.

--- a/src/trash/readme.md
+++ b/src/trash/readme.md
@@ -1,4 +1,4 @@
-1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github.
+1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github. Add tokens per second perf measurement.
 
 # trash
 

--- a/src/trash/readme.md
+++ b/src/trash/readme.md
@@ -1,4 +1,4 @@
-1.0.0 Unified dispatcher for the Trash toolkit.
+1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github.
 
 # trash
 

--- a/src/trash/trash.csproj
+++ b/src/trash/trash.csproj
@@ -19,7 +19,7 @@ Usage: trash <command> [options]  (e.g. trash trgen, trash gen, trash trparse)]]
 		<PublishRepositoryUrl>true</PublishRepositoryUrl>
 		<DebugType>portable</DebugType>
 		<DebugSymbols>true</DebugSymbols>
-		<Version>1.0.0</Version>
+		<Version>1.1.0</Version>
 		<RepositoryUrl>https://github.com/kaby76/Trash/tree/main/src/trash</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
 	</PropertyGroup>

--- a/src/trcaret/Config.cs
+++ b/src/trcaret/Config.cs
@@ -17,6 +17,6 @@ namespace Trash
         public bool Verbose { get; set; }
 
 	[Option("version", Required = false)]
-	public string Version { get; set; } = "1.0.0";
+	public string Version { get; set; } = "1.1.0";
     }
 }

--- a/src/trcaret/readme.md
+++ b/src/trcaret/readme.md
@@ -18,7 +18,7 @@ Reads a tree from stdin and prints lines and caret marks.
 
 ## Current version
 
-1.0.0 Unified dispatcher for the Trash toolkit.
+1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github.
 
 ## License
 

--- a/src/trcaret/readme.md
+++ b/src/trcaret/readme.md
@@ -18,7 +18,7 @@ Reads a tree from stdin and prints lines and caret marks.
 
 ## Current version
 
-1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github.
+1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github. Add tokens per second perf measurement.
 
 ## License
 

--- a/src/trcaret/trcaret.csproj
+++ b/src/trcaret/trcaret.csproj
@@ -20,7 +20,7 @@ This program is part of the Trash toolkit.
 		<PublishRepositoryUrl>true</PublishRepositoryUrl>
 		<DebugType>portable</DebugType>
 		<DebugSymbols>true</DebugSymbols>
-		<Version>1.0.0</Version>
+		<Version>1.1.0</Version>
 		<RepositoryUrl>https://github.com/kaby76/Trash/tree/main/src/trcaret</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
 	</PropertyGroup>

--- a/src/trclonereplace/Config.cs
+++ b/src/trclonereplace/Config.cs
@@ -21,5 +21,5 @@ public class Config
     public string Suffix { get; set; }
 
     [Option("version", Required = false)]
-    public string Version { get; set; } = "1.0.0";
+    public string Version { get; set; } = "1.1.0";
 }

--- a/src/trclonereplace/readme.md
+++ b/src/trclonereplace/readme.md
@@ -19,7 +19,7 @@ Clone, rename, and replace symbols in a grammar to optimize full stack fallbacks
 
 ## Current version
 
-1.0.0 Unified dispatcher for the Trash toolkit.
+1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github.
 
 ## License
 

--- a/src/trclonereplace/readme.md
+++ b/src/trclonereplace/readme.md
@@ -19,7 +19,7 @@ Clone, rename, and replace symbols in a grammar to optimize full stack fallbacks
 
 ## Current version
 
-1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github.
+1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github. Add tokens per second perf measurement.
 
 ## License
 

--- a/src/trclonereplace/trclonereplace.csproj
+++ b/src/trclonereplace/trclonereplace.csproj
@@ -18,7 +18,7 @@ This program is part of the Trash toolkit.]]>
 		<PublishRepositoryUrl>true</PublishRepositoryUrl>
 		<DebugType>portable</DebugType>
 		<DebugSymbols>true</DebugSymbols>
-		<Version>1.0.0</Version>
+		<Version>1.1.0</Version>
 		<RepositoryUrl>https://github.com/kaby76/Trash/tree/main/src/trclonereplace</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
 	</PropertyGroup>

--- a/src/trcombine/Config.cs
+++ b/src/trcombine/Config.cs
@@ -14,6 +14,6 @@ namespace Trash
         public bool Verbose { get; set; }
 
 	[Option("version", Required = false)]
-	public string Version { get; set; } = "1.0.0";
+	public string Version { get; set; } = "1.1.0";
     }
 }

--- a/src/trcombine/readme.md
+++ b/src/trcombine/readme.md
@@ -103,7 +103,7 @@ The original grammars are left unchanged.
 
 ## Current version
 
-1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github.
+1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github. Add tokens per second perf measurement.
 
 ## License
 

--- a/src/trcombine/readme.md
+++ b/src/trcombine/readme.md
@@ -103,7 +103,7 @@ The original grammars are left unchanged.
 
 ## Current version
 
-1.0.0 Unified dispatcher for the Trash toolkit.
+1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github.
 
 ## License
 

--- a/src/trcombine/trcombine.csproj
+++ b/src/trcombine/trcombine.csproj
@@ -18,7 +18,7 @@ This program is part of the Trash toolkit.]]>
 		<PublishRepositoryUrl>true</PublishRepositoryUrl>
 		<DebugType>portable</DebugType>
 		<DebugSymbols>true</DebugSymbols>
-		<Version>1.0.0</Version>
+		<Version>1.1.0</Version>
 		<RepositoryUrl>https://github.com/kaby76/Trash/tree/main/src/trcombine</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
 	</PropertyGroup>

--- a/src/trconvert/Config.cs
+++ b/src/trconvert/Config.cs
@@ -17,6 +17,6 @@ namespace Trash
         public bool Verbose { get; set; }
 
 	[Option("version", Required = false)]
-	public string Version { get; set; } = "1.0.0";
+	public string Version { get; set; } = "1.1.0";
     }
 }

--- a/src/trconvert/readme.md
+++ b/src/trconvert/readme.md
@@ -93,7 +93,7 @@ _Output_
 
 ## Current version
 
-1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github.
+1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github. Add tokens per second perf measurement.
 
 ## License
 

--- a/src/trconvert/readme.md
+++ b/src/trconvert/readme.md
@@ -93,7 +93,7 @@ _Output_
 
 ## Current version
 
-1.0.0 Unified dispatcher for the Trash toolkit.
+1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github.
 
 ## License
 

--- a/src/trconvert/trconvert.csproj
+++ b/src/trconvert/trconvert.csproj
@@ -19,7 +19,7 @@ syntax. This program is part of the Trash toolkit.]]>
 		<PublishRepositoryUrl>true</PublishRepositoryUrl>
 		<DebugType>portable</DebugType>
 		<DebugSymbols>true</DebugSymbols>
-		<Version>1.0.0</Version>
+		<Version>1.1.0</Version>
 		<RepositoryUrl>https://github.com/kaby76/Trash/tree/main/src/trconvert</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
 	</PropertyGroup>

--- a/src/trcover/Config.cs
+++ b/src/trcover/Config.cs
@@ -33,6 +33,6 @@ namespace Trash
         public bool ReadFileNameStdin { get; set; }
 
 	[Option("version", Required = false)]
-	public string Version { get; set; } = "1.0.0";
+	public string Version { get; set; } = "1.1.0";
     }
 }

--- a/src/trcover/readme.md
+++ b/src/trcover/readme.md
@@ -24,7 +24,7 @@ a grammar.
 
 ## Current version
 
-1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github.
+1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github. Add tokens per second perf measurement.
 
 ## License
 

--- a/src/trcover/readme.md
+++ b/src/trcover/readme.md
@@ -24,7 +24,7 @@ a grammar.
 
 ## Current version
 
-1.0.0 Unified dispatcher for the Trash toolkit.
+1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github.
 
 ## License
 

--- a/src/trcover/trcover.csproj
+++ b/src/trcover/trcover.csproj
@@ -19,7 +19,7 @@ for the entire grammar. This program is part of the Trash toolkit.]]>
 		<PublishRepositoryUrl>true</PublishRepositoryUrl>
 		<DebugType>portable</DebugType>
 		<DebugSymbols>true</DebugSymbols>
-		<Version>1.0.0</Version>
+		<Version>1.1.0</Version>
 		<RepositoryUrl>https://github.com/kaby76/Trash/tree/main/src/trcover</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
 	</PropertyGroup>

--- a/src/trdistill/Config.cs
+++ b/src/trdistill/Config.cs
@@ -17,6 +17,6 @@ namespace Trash
         public bool Verbose { get; set; }
 
 	[Option("version", Required = false)]
-	public string Version { get; set; } = "1.0.0";
+	public string Version { get; set; } = "1.1.0";
     }
 }

--- a/src/trdistill/readme.md
+++ b/src/trdistill/readme.md
@@ -93,7 +93,7 @@ _Output_
 
 ## Current version
 
-1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github.
+1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github. Add tokens per second perf measurement.
 
 ## License
 

--- a/src/trdistill/readme.md
+++ b/src/trdistill/readme.md
@@ -93,7 +93,7 @@ _Output_
 
 ## Current version
 
-1.0.0 Unified dispatcher for the Trash toolkit.
+1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github.
 
 ## License
 

--- a/src/trdistill/trdistill.csproj
+++ b/src/trdistill/trdistill.csproj
@@ -19,7 +19,7 @@ syntax. This program is part of the Trash toolkit.]]>
 		<PublishRepositoryUrl>true</PublishRepositoryUrl>
 		<DebugType>portable</DebugType>
 		<DebugSymbols>true</DebugSymbols>
-		<Version>1.0.0</Version>
+		<Version>1.1.0</Version>
 		<RepositoryUrl>https://github.com/kaby76/Trash/tree/main/src/trdistill</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
 	</PropertyGroup>

--- a/src/trdot/Config.cs
+++ b/src/trdot/Config.cs
@@ -14,6 +14,6 @@ public class Config
     public bool Verbose { get; set; }
 
     [Option("version", Required = false)]
-    public string Version { get; set; } = "1.0.0";
+    public string Version { get; set; } = "1.1.0";
 }
 

--- a/src/trdot/readme.md
+++ b/src/trdot/readme.md
@@ -63,7 +63,7 @@ The output will be:
 
 ## Current version
 
-1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github.
+1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github. Add tokens per second perf measurement.
 
 ## License
 

--- a/src/trdot/readme.md
+++ b/src/trdot/readme.md
@@ -63,7 +63,7 @@ The output will be:
 
 ## Current version
 
-1.0.0 Unified dispatcher for the Trash toolkit.
+1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github.
 
 ## License
 

--- a/src/trdot/trdot.csproj
+++ b/src/trdot/trdot.csproj
@@ -19,7 +19,7 @@ This program is part of the Trash toolkit.
 		<PublishRepositoryUrl>true</PublishRepositoryUrl>
 		<DebugType>portable</DebugType>
 		<DebugSymbols>true</DebugSymbols>
-		<Version>1.0.0</Version>
+		<Version>1.1.0</Version>
 		<RepositoryUrl>https://github.com/kaby76/Trash/tree/main/src/trdot</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
 	</PropertyGroup>

--- a/src/trenum/Config.cs
+++ b/src/trenum/Config.cs
@@ -12,6 +12,6 @@ namespace Trash
         public bool Verbose { get; set; }
 
 	[Option("version", Required = false)]
-	public string Version { get; set; } = "1.0.0";
+	public string Version { get; set; } = "1.1.0";
     }
 }

--- a/src/trenum/readme.md
+++ b/src/trenum/readme.md
@@ -8,7 +8,7 @@
 
 ## Current version
 
-1.0.0 Unified dispatcher for the Trash toolkit.
+1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github.
 
 ## License
 

--- a/src/trenum/readme.md
+++ b/src/trenum/readme.md
@@ -8,7 +8,7 @@
 
 ## Current version
 
-1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github.
+1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github. Add tokens per second perf measurement.
 
 ## License
 

--- a/src/trenum/trenum.csproj
+++ b/src/trenum/trenum.csproj
@@ -19,7 +19,7 @@ This program is part of the Trash toolkit.
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <DebugType>portable</DebugType>
     <DebugSymbols>true</DebugSymbols>
-    <Version>1.0.0</Version>
+    <Version>1.1.0</Version>
     <RepositoryUrl>https://github.com/kaby76/Trash/tree/main/src/trull</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
   </PropertyGroup>

--- a/src/trextract/Config.cs
+++ b/src/trextract/Config.cs
@@ -14,6 +14,6 @@ namespace Trash
         public bool Verbose { get; set; }
 
 	[Option("version", Required = false)]
-	public string Version { get; set; } = "1.0.0";
+	public string Version { get; set; } = "1.1.0";
     }
 }

--- a/src/trextract/readme.md
+++ b/src/trextract/readme.md
@@ -33,7 +33,7 @@ The outputed files are:
 
 ## Current version
 
-1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github.
+1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github. Add tokens per second perf measurement.
 
 ## License
 

--- a/src/trextract/readme.md
+++ b/src/trextract/readme.md
@@ -33,7 +33,7 @@ The outputed files are:
 
 ## Current version
 
-1.0.0 Unified dispatcher for the Trash toolkit.
+1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github.
 
 ## License
 

--- a/src/trextract/trextract.csproj
+++ b/src/trextract/trextract.csproj
@@ -18,7 +18,7 @@ This program is part of the Trash toolkit.]]>
 		<PublishRepositoryUrl>true</PublishRepositoryUrl>
 		<DebugType>portable</DebugType>
 		<DebugSymbols>true</DebugSymbols>
-		<Version>1.0.0</Version>
+		<Version>1.1.0</Version>
 		<RepositoryUrl>https://github.com/kaby76/Trash/tree/main/src/trextract</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
 	</PropertyGroup>

--- a/src/trff/Config.cs
+++ b/src/trff/Config.cs
@@ -12,7 +12,7 @@ namespace Trash
         public bool Verbose { get; set; }
 
 	[Option("version", Required = false)]
-	public string Version { get; set; } = "1.0.0";
+	public string Version { get; set; } = "1.1.0";
 
         [Value(0, Required = false, Default = 1)]
         public int K { get; set; }

--- a/src/trff/readme.md
+++ b/src/trff/readme.md
@@ -22,7 +22,7 @@ XPaths, type _export MSYS2_ARG_CONV_EXCL="*"_, then execute your command.
 
 ## Current version
 
-1.0.0 Unified dispatcher for the Trash toolkit.
+1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github.
 
 ## License
 

--- a/src/trff/readme.md
+++ b/src/trff/readme.md
@@ -22,7 +22,7 @@ XPaths, type _export MSYS2_ARG_CONV_EXCL="*"_, then execute your command.
 
 ## Current version
 
-1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github.
+1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github. Add tokens per second perf measurement.
 
 ## License
 

--- a/src/trff/trff.csproj
+++ b/src/trff/trff.csproj
@@ -18,7 +18,7 @@ This program is part of the Trash toolkit.]]>
 		<PublishRepositoryUrl>true</PublishRepositoryUrl>
 		<DebugType>portable</DebugType>
 		<DebugSymbols>true</DebugSymbols>
-		<Version>1.0.0</Version>
+		<Version>1.1.0</Version>
 		<RepositoryUrl>https://github.com/kaby76/Trash/tree/main/src/trff</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
 	</PropertyGroup>

--- a/src/trfold/Config.cs
+++ b/src/trfold/Config.cs
@@ -15,7 +15,7 @@ namespace Trash
         public bool Verbose { get; set; }
 
 	[Option("version", Required = false)]
-	public string Version { get; set; } = "1.0.0";
+	public string Version { get; set; } = "1.1.0";
 
         [Value(0, Min = 1)]
         public IEnumerable<string> Expr { get; set; }

--- a/src/trfold/readme.md
+++ b/src/trfold/readme.md
@@ -26,7 +26,7 @@ XPaths, type _export MSYS2_ARG_CONV_EXCL="*"_, then execute your command.
 
 ## Current version
 
-1.0.0 Unified dispatcher for the Trash toolkit.
+1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github.
 
 ## License
 

--- a/src/trfold/readme.md
+++ b/src/trfold/readme.md
@@ -26,7 +26,7 @@ XPaths, type _export MSYS2_ARG_CONV_EXCL="*"_, then execute your command.
 
 ## Current version
 
-1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github.
+1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github. Add tokens per second perf measurement.
 
 ## License
 

--- a/src/trfold/trfold.csproj
+++ b/src/trfold/trfold.csproj
@@ -18,7 +18,7 @@ This program is part of the Trash toolkit.]]>
 		<PublishRepositoryUrl>true</PublishRepositoryUrl>
 		<DebugType>portable</DebugType>
 		<DebugSymbols>true</DebugSymbols>
-		<Version>1.0.0</Version>
+		<Version>1.1.0</Version>
 		<RepositoryUrl>https://github.com/kaby76/Trash/tree/main/src/trfold</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
 	</PropertyGroup>

--- a/src/trfoldlit/Config.cs
+++ b/src/trfoldlit/Config.cs
@@ -15,7 +15,7 @@ namespace Trash
         public bool Verbose { get; set; }
 
 	[Option("version", Required = false)]
-	public string Version { get; set; } = "1.0.0";
+	public string Version { get; set; } = "1.1.0";
 
         [Value(0)]
         public IEnumerable<string> Expr { get; set; }

--- a/src/trfoldlit/readme.md
+++ b/src/trfoldlit/readme.md
@@ -65,7 +65,7 @@ XPaths, type _export MSYS2_ARG_CONV_EXCL="*"_, then execute your command.
 
 ## Current version
 
-1.0.0 Unified dispatcher for the Trash toolkit.
+1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github.
 
 ## License
 

--- a/src/trfoldlit/readme.md
+++ b/src/trfoldlit/readme.md
@@ -65,7 +65,7 @@ XPaths, type _export MSYS2_ARG_CONV_EXCL="*"_, then execute your command.
 
 ## Current version
 
-1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github.
+1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github. Add tokens per second perf measurement.
 
 ## License
 

--- a/src/trfoldlit/trfoldlit.csproj
+++ b/src/trfoldlit/trfoldlit.csproj
@@ -18,7 +18,7 @@ This program is part of the Trash toolkit.]]>
 		<PublishRepositoryUrl>true</PublishRepositoryUrl>
 		<DebugType>portable</DebugType>
 		<DebugSymbols>true</DebugSymbols>
-		<Version>1.0.0</Version>
+		<Version>1.1.0</Version>
 		<RepositoryUrl>https://github.com/kaby76/Trash/tree/main/src/trfoldlit</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
 	</PropertyGroup>

--- a/src/trformat/Config.cs
+++ b/src/trformat/Config.cs
@@ -15,6 +15,6 @@ namespace Trash
         public bool Verbose { get; set; }
 
 	[Option("version", Required = false)]
-	public string Version { get; set; } = "1.0.0";
+	public string Version { get; set; } = "1.1.0";
     }
 }

--- a/src/trformat/readme.md
+++ b/src/trformat/readme.md
@@ -18,7 +18,7 @@ Format of grammar using machine learning.
 
 ## Current version
 
-1.0.0 Unified dispatcher for the Trash toolkit.
+1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github.
 
 ## License
 

--- a/src/trformat/readme.md
+++ b/src/trformat/readme.md
@@ -18,7 +18,7 @@ Format of grammar using machine learning.
 
 ## Current version
 
-1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github.
+1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github. Add tokens per second perf measurement.
 
 ## License
 

--- a/src/trformat/trformat.csproj
+++ b/src/trformat/trformat.csproj
@@ -18,7 +18,7 @@ This program is part of the Trash toolkit.]]>
 		<PublishRepositoryUrl>true</PublishRepositoryUrl>
 		<DebugType>portable</DebugType>
 		<DebugSymbols>true</DebugSymbols>
-		<Version>1.0.0</Version>
+		<Version>1.1.0</Version>
 		<RepositoryUrl>https://github.com/kaby76/Trash/tree/main/src/trformat</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
 	</PropertyGroup>

--- a/src/trgen/Command.cs
+++ b/src/trgen/Command.cs
@@ -586,7 +586,7 @@ namespace Trash
             }
         }
 
-        public static string version = "1.0.0";
+        public static string version = "1.1.0";
 
         // For maven-generated code.
         public List<string> failed_modules = new List<string>();

--- a/src/trgen/Config.cs
+++ b/src/trgen/Config.cs
@@ -146,5 +146,5 @@ public class Config
     public bool deps { get; set; }
 
     [Option("version", Required = false)]
-    public string Version { get; set; } = "1.0.0";
+    public string Version { get; set; } = "1.1.0";
 }

--- a/src/trgen/readme.md
+++ b/src/trgen/readme.md
@@ -49,7 +49,7 @@ simplify and eliminate bugs created when adding new grammars.
 
 ## Current version
 
-1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github.
+1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github. Add tokens per second perf measurement.
 
 ## License
 

--- a/src/trgen/readme.md
+++ b/src/trgen/readme.md
@@ -49,7 +49,7 @@ simplify and eliminate bugs created when adding new grammars.
 
 ## Current version
 
-1.0.0 Unified dispatcher for the Trash toolkit.
+1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github.
 
 ## License
 

--- a/src/trgen/templates/Antlr4cs/st.Test.cs
+++ b/src/trgen/templates/Antlr4cs/st.Test.cs
@@ -201,7 +201,8 @@ public class Program
         DateTime before = DateTime.Now;
         var tree = parser.<start_symbol>();
         DateTime after = DateTime.Now;
-        total_tokens += tokens.Size;
+        var token_count = tokens.Size;
+        total_tokens += token_count;
         var result = "";
         if (parser.NumberOfSyntaxErrors > 0)
         {
@@ -224,7 +225,7 @@ public class Program
         }
         if (!quiet)
         {
-            System.Console.Error.WriteLine(prefix + "Antlr4cs " + row_number + " " + input_name + " " + result + " " + (after - before).TotalSeconds);
+            System.Console.Error.WriteLine(prefix + "Antlr4cs " + row_number + " " + input_name + " " + result + " " + (after - before).TotalSeconds + " s " + (long)(token_count / (after - before).TotalSeconds) + " tps");
         }
         if (tee) output.Close();
     }

--- a/src/trgen/templates/Antlr4cs/st.Test.cs
+++ b/src/trgen/templates/Antlr4cs/st.Test.cs
@@ -35,6 +35,7 @@ public class Program
     static int string_instance = 0;
     static string prefix = "";
     static bool quiet = false;
+    static long total_tokens = 0;
 
     static void Main(string[] args)
     {
@@ -125,7 +126,7 @@ public class Program
             DateTime after = DateTime.Now;
             if (!quiet)
             {
-                System.Console.Error.WriteLine(prefix + "Total Time: " + (after - before).TotalSeconds);
+                System.Console.Error.WriteLine(prefix + "Total Time: " + (after - before).TotalSeconds + " Tokens per second: " + (long)(total_tokens / (after - before).TotalSeconds));
             }
         }
         Environment.ExitCode = exit_code;
@@ -200,6 +201,7 @@ public class Program
         DateTime before = DateTime.Now;
         var tree = parser.<start_symbol>();
         DateTime after = DateTime.Now;
+        total_tokens += tokens.Size;
         var result = "";
         if (parser.NumberOfSyntaxErrors > 0)
         {

--- a/src/trgen/templates/Antlr4cs/st.Test.csproj
+++ b/src/trgen/templates/Antlr4cs/st.Test.csproj
@@ -28,7 +28,7 @@
     -->
     \<MyTester>\<![CDATA[
 err=0
-for g in `dotnet trglob -- '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
+for g in `dotnet trash glob -- '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
 do
   file=$g
   x1="${g##*.}"

--- a/src/trgen/templates/Antlr4ng/st.Test.ts
+++ b/src/trgen/templates/Antlr4ng/st.Test.ts
@@ -190,7 +190,8 @@ function DoParse(str: CharStream, input_name: string, row_number: number) {
     timer.start();
     const tree = parser.<start_symbol>();
     timer.stop();
-    total_tokens += tokens.size;
+    var token_count = tokens.size;
+    total_tokens += token_count;
     var result = "";
     if (listener_parser.had_error || listener_lexer.had_error) {
         result = 'fail';
@@ -208,7 +209,7 @@ function DoParse(str: CharStream, input_name: string, row_number: number) {
         }
     }
     if (!quiet) {
-        console.error(prefix + 'TypeScript ' + row_number + ' ' + input_name + ' ' + result + ' ' + t);
+        console.error(prefix + 'TypeScript ' + row_number + ' ' + input_name + ' ' + result + ' ' + t + ' s ' + Math.round(token_count / t) + ' tps');
     }
     if (tee) {
         closeSync(output);

--- a/src/trgen/templates/Antlr4ng/st.Test.ts
+++ b/src/trgen/templates/Antlr4ng/st.Test.ts
@@ -57,6 +57,7 @@ var enc = '<file_encoding>';
 var binary = <binary>;
 var string_instance = 0;
 var prefix = '';
+var total_tokens = 0;
 var inputs: string[] = [];
 var is_fns: boolean[] = [];
 
@@ -128,7 +129,7 @@ function main() {
         }
         timer.stop();
         var t = timer.time().m * 60 + timer.time().s + timer.time().ms / 1000;
-        if (!quiet) console.error(prefix + 'Total Time: ' + t);
+        if (!quiet) console.error(prefix + 'Total Time: ' + t + ' Tokens per second: ' + Math.round(total_tokens / t));
     }
     process.exitCode = error_code;
 }
@@ -189,6 +190,7 @@ function DoParse(str: CharStream, input_name: string, row_number: number) {
     timer.start();
     const tree = parser.<start_symbol>();
     timer.stop();
+    total_tokens += tokens.size;
     var result = "";
     if (listener_parser.had_error || listener_lexer.had_error) {
         result = 'fail';

--- a/src/trgen/templates/CSharp/st.Test.cs
+++ b/src/trgen/templates/CSharp/st.Test.cs
@@ -434,7 +434,8 @@ public class Program
         DateTime before = DateTime.Now;
         var tree = parser.<start_symbol>();
         DateTime after = DateTime.Now;
-        total_tokens += tokens.Size;
+        var token_count = tokens.Size;
+        total_tokens += token_count;
         var result = "";
         if (listener_lexer.had_error || listener_parser.had_error)
         {
@@ -496,7 +497,7 @@ public class Program
         }
         if (!quiet)
         {
-            System.Console.Error.WriteLine(prefix + "CSharp " + row_number + " " + input_name + " " + result + " " + (after - before).TotalSeconds);
+            System.Console.Error.WriteLine(prefix + "CSharp " + row_number + " " + input_name + " " + result + " " + (after - before).TotalSeconds + " s " + (long)(token_count / (after - before).TotalSeconds) + " tps");
         }
 
         if (earley) {

--- a/src/trgen/templates/CSharp/st.Test.cs
+++ b/src/trgen/templates/CSharp/st.Test.cs
@@ -176,6 +176,7 @@ public class Program
     static bool show_tokens = false;
     static bool show_token_count = false;
     static long total_count = 0;
+    static long total_tokens = 0;
     static bool show_trace = false;
     static bool show_tree = false;
     static bool old = false;
@@ -328,7 +329,7 @@ public class Program
                     ParseString(inputs[f], f);
             }
             DateTime after = DateTime.Now;
-            if (!quiet) System.Console.Error.WriteLine(prefix + "Total Time: " + (after - before).TotalSeconds);
+            if (!quiet) System.Console.Error.WriteLine(prefix + "Total Time: " + (after - before).TotalSeconds + " Tokens per second: " + (long)(total_tokens / (after - before).TotalSeconds));
             if (show_token_count) System.Console.Error.WriteLine("TC: " + total_count);
         }
         Environment.ExitCode = exit_code;
@@ -359,6 +360,8 @@ public class Program
             str = new Antlr4.Runtime.AntlrInputStream(fs);
         }
         else if (file_encoding == null || file_encoding == "")
+            str = CharStreams.fromPath(input);
+        else if (file_encoding == "detect")
         {
             var detected = CharsetDetector.DetectFromFile(input);
             var enc = detected.Detected?.Encoding ?? Encoding.UTF8;
@@ -431,6 +434,7 @@ public class Program
         DateTime before = DateTime.Now;
         var tree = parser.<start_symbol>();
         DateTime after = DateTime.Now;
+        total_tokens += tokens.Size;
         var result = "";
         if (listener_lexer.had_error || listener_parser.had_error)
         {

--- a/src/trgen/templates/Cpp/st.Test.cpp
+++ b/src/trgen/templates/Cpp/st.Test.cpp
@@ -90,7 +90,8 @@ void DoParse(antlr4::CharStream* str, std::string input_name, int row_number)
     auto before = std::chrono::steady_clock::now();
     auto* tree = parser-><start_symbol>();
     auto after = std::chrono::steady_clock::now();
-    total_tokens += (long)tokens->size();
+    long token_count = (long)tokens->size();
+    total_tokens += token_count;
     auto duration = std::chrono::duration_cast\<std::chrono::microseconds>(after - before);
     std::string result;
     if (listener_parser->had_error || listener_lexer->had_error)
@@ -122,7 +123,7 @@ void DoParse(antlr4::CharStream* str, std::string input_name, int row_number)
     }
     if (!quiet)
     {
-        std::cerr \<\< prefix \<\< "Cpp " \<\< row_number \<\< " " \<\< input_name \<\< " " \<\< result \<\< " " \<\< formatDurationSeconds(duration.count()) \<\< std::endl;
+        std::cerr \<\< prefix \<\< "Cpp " \<\< row_number \<\< " " \<\< input_name \<\< " " \<\< result \<\< " " \<\< formatDurationSeconds(duration.count()) \<\< " s " \<\< (long)(token_count / (duration.count() / 1000000.0)) \<\< " tps" \<\< std::endl;
     }
     if (tee)
     {

--- a/src/trgen/templates/Cpp/st.Test.cpp
+++ b/src/trgen/templates/Cpp/st.Test.cpp
@@ -53,6 +53,7 @@ int string_instance = 0;
 std::string prefix;
 bool quiet = false;
 std::string file_encoding = "<file_encoding>";
+long total_tokens = 0;
 
 void DoParse(antlr4::CharStream* str, std::string input_name, int row_number)
 {
@@ -89,6 +90,7 @@ void DoParse(antlr4::CharStream* str, std::string input_name, int row_number)
     auto before = std::chrono::steady_clock::now();
     auto* tree = parser-><start_symbol>();
     auto after = std::chrono::steady_clock::now();
+    total_tokens += (long)tokens->size();
     auto duration = std::chrono::duration_cast\<std::chrono::microseconds>(after - before);
     std::string result;
     if (listener_parser->had_error || listener_lexer->had_error)
@@ -241,7 +243,7 @@ int TryParse(std::vector\<std::string>& args)
         }
         auto after = std::chrono::steady_clock::now();
         auto duration = std::chrono::duration_cast\<std::chrono::microseconds>(after - before);
-        if (! quiet) std::cerr \<\< prefix \<\< "Total Time: " \<\< formatDurationSeconds(duration.count()) \<\< std::endl;
+        if (! quiet) std::cerr \<\< prefix \<\< "Total Time: " \<\< formatDurationSeconds(duration.count()) \<\< " Tokens per second: " \<\< (long)(total_tokens / (duration.count() / 1000000.0)) \<\< std::endl;
     }
     return error_code;
 }

--- a/src/trgen/templates/Cpp/st.build.ps1
+++ b/src/trgen/templates/Cpp/st.build.ps1
@@ -24,7 +24,7 @@ npm i antlr-ng
 echo HOME $HOME
 
 <if(test.IsWindows)>
-$(& cmake .. -G "Visual Studio 17 2022" -A x64 -DHOME=$HOME ; $compile_exit_code = $LASTEXITCODE ) | Write-Host
+$(& cmake .. -G "Visual Studio 18 2026" -A x64 -DHOME=$HOME ; $compile_exit_code = $LASTEXITCODE ) | Write-Host
 <else>$(& cmake .. -DHOME=$HOME ; $compile_exit_code = $LASTEXITCODE ) | Write-Host
 <endif>
 if($compile_exit_code -ne 0){

--- a/src/trgen/templates/Cpp/st.build.sh
+++ b/src/trgen/templates/Cpp/st.build.sh
@@ -9,7 +9,7 @@ cd build
 npm init -y
 npm i antlr-ng
 <endif>
-<if(test.IsWindows)>cmake .. -G "Visual Studio 17 2022" -A x64
+<if(test.IsWindows)>cmake .. -G "Visual Studio 18 2026" -A x64
 <else>cmake ..
 <endif>
 <if(test.IsWindows)>cmake --build . --config Release

--- a/src/trgen/templates/Dart/st.Test.dart
+++ b/src/trgen/templates/Dart/st.Test.dart
@@ -221,7 +221,8 @@ Future\<void> DoParse(CharStream str, String input_name, int row_number) async
     s.start();
     var tree = parser.<start_symbol>();
     s.stop();
-    total_tokens += tokens.size;
+    var token_count = tokens.size;
+    total_tokens += token_count;
     var et = s.elapsedMilliseconds / 1000.0;
     var result = "";
     if (parser.numberOfSyntaxErrors > 0)
@@ -251,7 +252,7 @@ Future\<void> DoParse(CharStream str, String input_name, int row_number) async
     }
     if (!quiet)
     {
-        stderr.writeln(prefix + "Dart " + row_number.toString() + " " + input_name + " " + result + " " + et.toString());
+        stderr.writeln(prefix + "Dart " + row_number.toString() + " " + input_name + " " + result + " " + et.toString() + " s " + (et > 0 ? (token_count / et).round().toString() : "0") + " tps");
     }
     if (tee)
     {

--- a/src/trgen/templates/Dart/st.Test.dart
+++ b/src/trgen/templates/Dart/st.Test.dart
@@ -60,6 +60,7 @@ var error_code = 0;
 var string_instance = 0;
 var prefix = "";
 var quiet = false;
+var total_tokens = 0;
 
 void main(List\<String> args) async {
     // Set command-line args before anything else.
@@ -136,7 +137,7 @@ void main(List\<String> args) async {
         }
         s.stop();
         var et = s.elapsedMilliseconds / 1000.0;
-        if (!quiet) stderr.writeln(prefix + "Total Time: " + et.toString());
+        if (!quiet) stderr.writeln(prefix + "Total Time: " + et.toString() + " Tokens per second: " + (et > 0 ? (total_tokens / et).round().toString() : "0"));
     }
     exit(error_code);
 }
@@ -220,6 +221,7 @@ Future\<void> DoParse(CharStream str, String input_name, int row_number) async
     s.start();
     var tree = parser.<start_symbol>();
     s.stop();
+    total_tokens += tokens.size;
     var et = s.elapsedMilliseconds / 1000.0;
     var result = "";
     if (parser.numberOfSyntaxErrors > 0)

--- a/src/trgen/templates/Go/Test.go.st
+++ b/src/trgen/templates/Go/Test.go.st
@@ -203,7 +203,8 @@ func DoParse(str antlr.CharStream, input_name string, row_number int) {
     start := time.Now()
     var tree = parser.<cap_start_symbol>()
     elapsed := time.Since(start)
-    total_tokens += int64(len(tokens.GetAllTokens()))
+    token_count := int64(len(tokens.GetAllTokens()))
+    total_tokens += token_count
     var result = ""
     if parserErrors.errors > 0 || lexerErrors.errors > 0 {
         result = "fail"
@@ -230,7 +231,7 @@ func DoParse(str antlr.CharStream, input_name string, row_number int) {
         fmt.Fprintf(os.Stderr, "%d ", row_number)
         fmt.Fprintf(os.Stderr, "%s ", input_name)
         fmt.Fprintf(os.Stderr, "%s ", result)
-        fmt.Fprintf(os.Stderr, "%.3f", elapsed.Seconds())
+        fmt.Fprintf(os.Stderr, "%.3f s %.0f tps", elapsed.Seconds(), float64(token_count)/elapsed.Seconds())
         fmt.Fprintln(os.Stderr)
     }
 }

--- a/src/trgen/templates/Go/Test.go.st
+++ b/src/trgen/templates/Go/Test.go.st
@@ -67,6 +67,7 @@ var prefix = ""
 var quiet = false
 var tee = false
 var binary = <binary>
+var total_tokens int64 = 0
 
 func main() {
     for i := 1; i \< len(os.Args); i = i + 1 {
@@ -114,7 +115,7 @@ func main() {
         }
         elapsed := time.Since(start)
         if ! quiet {
-            fmt.Fprintf(os.Stderr, "%sTotal Time: %.3f", prefix, elapsed.Seconds())
+            fmt.Fprintf(os.Stderr, "%sTotal Time: %.3f Tokens per second: %.0f", prefix, elapsed.Seconds(), float64(total_tokens)/elapsed.Seconds())
             fmt.Fprintln(os.Stderr)
         }
     }
@@ -202,6 +203,7 @@ func DoParse(str antlr.CharStream, input_name string, row_number int) {
     start := time.Now()
     var tree = parser.<cap_start_symbol>()
     elapsed := time.Since(start)
+    total_tokens += int64(len(tokens.GetAllTokens()))
     var result = ""
     if parserErrors.errors > 0 || lexerErrors.errors > 0 {
         result = "fail"

--- a/src/trgen/templates/Java/st.Test.java
+++ b/src/trgen/templates/Java/st.Test.java
@@ -34,6 +34,7 @@ public class Test {
     static int string_instance = 0;
     static String prefix = "";
     static boolean quiet = false;
+    static long total_tokens = 0;
 
     public static void main(String[] args) throws  FileNotFoundException, IOException
     {
@@ -122,7 +123,7 @@ public class Test {
             }
             Instant finish = Instant.now();
             long timeElapsed = Duration.between(start, finish).toMillis();
-            if (!quiet) System.err.println(prefix + "Total Time: " + (timeElapsed * 1.0) / 1000.0);
+            if (!quiet) System.err.println(prefix + "Total Time: " + (timeElapsed * 1.0) / 1000.0 + " Tokens per second: " + (long)(total_tokens / ((timeElapsed * 1.0) / 1000.0)));
         }
         java.lang.System.exit(error_code);
     }
@@ -197,6 +198,7 @@ public class Test {
         ParseTree tree = parser.<start_symbol>();
         Instant finish = Instant.now();
         long timeElapsed = Duration.between(start, finish).toMillis();
+        total_tokens += tokens.size();
         String result = "";
         if (listener_parser.had_error || listener_lexer.had_error)
         {

--- a/src/trgen/templates/Java/st.Test.java
+++ b/src/trgen/templates/Java/st.Test.java
@@ -198,7 +198,8 @@ public class Test {
         ParseTree tree = parser.<start_symbol>();
         Instant finish = Instant.now();
         long timeElapsed = Duration.between(start, finish).toMillis();
-        total_tokens += tokens.size();
+        long token_count = tokens.size();
+        total_tokens += token_count;
         String result = "";
         if (listener_parser.had_error || listener_lexer.had_error)
         {
@@ -229,7 +230,7 @@ public class Test {
         }
         if (!quiet)
         {
-            System.err.println(prefix + "Java " + row_number + " " + input_name + " " + result + " " + (timeElapsed * 1.0) / 1000.0);
+            System.err.println(prefix + "Java " + row_number + " " + input_name + " " + result + " " + (timeElapsed * 1.0) / 1000.0 + " s " + (long)(token_count / ((timeElapsed * 1.0) / 1000.0)) + " tps");
         }
         if (tee) output.close();
     }

--- a/src/trgen/templates/JavaScript/st.Test.js
+++ b/src/trgen/templates/JavaScript/st.Test.js
@@ -57,6 +57,7 @@ var enc = '<file_encoding>';
 var binary = <binary>;
 var string_instance = 0;
 var prefix = '';
+var total_tokens = 0;
 var inputs = [];
 var is_fns = [];
 
@@ -128,7 +129,7 @@ function main() {
         }
         timer.stop();
         var t = timer.time().m * 60 + timer.time().s + timer.time().ms / 1000;
-        if (!quiet) console.error(prefix + 'Total Time: ' + t);
+        if (!quiet) console.error(prefix + 'Total Time: ' + t + ' Tokens per second: ' + Math.round(total_tokens / t));
     }
     process.exitCode = error_code;
 }
@@ -188,6 +189,7 @@ function DoParse(str, input_name, row_number) {
     timer.start();
     const tree = parser.<start_symbol>();
     timer.stop();
+    total_tokens += tokens.size;
     var result = "";
     if (listener_parser.had_error || listener_lexer.had_error) {
         result = 'fail';

--- a/src/trgen/templates/JavaScript/st.Test.js
+++ b/src/trgen/templates/JavaScript/st.Test.js
@@ -189,7 +189,8 @@ function DoParse(str, input_name, row_number) {
     timer.start();
     const tree = parser.<start_symbol>();
     timer.stop();
-    total_tokens += tokens.size;
+    var token_count = tokens.size;
+    total_tokens += token_count;
     var result = "";
     if (listener_parser.had_error || listener_lexer.had_error) {
         result = 'fail';
@@ -207,7 +208,7 @@ function DoParse(str, input_name, row_number) {
         }
     }
     if (! quiet) {
-        console.error(prefix + 'JavaScript ' + row_number + ' ' + input_name + ' ' + result + ' ' + t);
+        console.error(prefix + 'JavaScript ' + row_number + ' ' + input_name + ' ' + result + ' ' + t + ' s ' + Math.round(token_count / t) + ' tps');
     }
     if (tee) {
         fs.closeSync(output);

--- a/src/trgen/templates/JavaScript/st.package.json
+++ b/src/trgen/templates/JavaScript/st.package.json
@@ -9,7 +9,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "antlr4": "<if(antlr_is_dev)>*<else><antlr_version><endif>",
+    "antlr4": "<if(antlr_is_dev)>*<else>4.13.2<endif>",
     "fs-extra": "^11.1.0",
     "timer-node": "^5.0.6",
     "typescript-string-operations": "^1.4.1"

--- a/src/trgen/templates/PHP/st.Test.php
+++ b/src/trgen/templates/PHP/st.Test.php
@@ -73,6 +73,7 @@ $error_code = 0;
 $string_instance = 0;
 $prefix = "";
 $quiet = false;
+$total_tokens = 0;
 
 function main($argv) : void {
     global $tee;
@@ -85,6 +86,7 @@ function main($argv) : void {
     global $error_code;
     global $prefix;
     global $quiet;
+    global $total_tokens;
     for ($i = 1; $i \< count($argv); $i++) {
         if ($argv[$i] == "-tokens") {
             $show_tokens = true;
@@ -128,7 +130,7 @@ function main($argv) : void {
         }
         $duration = $timer->stop();
         if (! $quiet) {
-            fwrite(STDERR, $prefix . "Total Time: " . $duration->asSeconds() . "\n");
+            fwrite(STDERR, $prefix . "Total Time: " . $duration->asSeconds() . " Tokens per second: " . (int)($total_tokens / $duration->asSeconds()) . "\n");
         }
     }
     exit($error_code);
@@ -166,6 +168,7 @@ function DoParse($str, $input_name, $row_number) {
     global $error_code;
     global $prefix;
     global $quiet;
+    global $total_tokens;
     $lexer = new <lexer_name>($str);
     if ($show_tokens) {
         for ($i=0;  ; $i++) {
@@ -200,6 +203,7 @@ function DoParse($str, $input_name, $row_number) {
     $timer2->start();
     $tree = $parser-><start_symbol>();
     $duration = $timer2->stop();
+    $total_tokens += $tokens->count();
     $result = "";
     if ($parserErrorListener->had_error || $lexerErrorListener->had_error) {
         $result = "fail";

--- a/src/trgen/templates/PHP/st.Test.php
+++ b/src/trgen/templates/PHP/st.Test.php
@@ -203,7 +203,8 @@ function DoParse($str, $input_name, $row_number) {
     $timer2->start();
     $tree = $parser-><start_symbol>();
     $duration = $timer2->stop();
-    $total_tokens += $tokens->count();
+    $token_count = $tokens->count();
+    $total_tokens += $token_count;
     $result = "";
     if ($parserErrorListener->had_error || $lexerErrorListener->had_error) {
         $result = "fail";
@@ -222,7 +223,7 @@ function DoParse($str, $input_name, $row_number) {
         }
     }
     if ( ! $quiet ) {
-        fwrite(STDERR, $prefix . "PHP " . $row_number . " " . $input_name . " " . $result . " " . $duration->asSeconds() . "\n");
+        fwrite(STDERR, $prefix . "PHP " . $row_number . " " . $input_name . " " . $result . " " . $duration->asSeconds() . " s " . (int)($token_count / $duration->asSeconds()) . " tps\n");
     }
     if ( $tee ) {
         fclose($output);

--- a/src/trgen/templates/Python3/st.Test.py
+++ b/src/trgen/templates/Python3/st.Test.py
@@ -40,6 +40,7 @@ string_instance = 0
 prefix = ""
 quiet = False
 noop = False
+total_tokens = 0
 
 def main(argv):
     global tee
@@ -102,7 +103,7 @@ def main(argv):
         diff = end_time - start_time
         diff_time = diff.total_seconds()
         if (not quiet):
-            print(f'{prefix}Total Time: {diff_time}', file=sys.stderr);
+            print(f'{prefix}Total Time: {diff_time} Tokens per second: {int(total_tokens / diff_time) if diff_time > 0 else 0}', file=sys.stderr);
     sys.exit(error_code)
 
 def ParseStdin():
@@ -138,6 +139,7 @@ def DoParse(str, input_name, row_number):
     global prefix
     global quiet
     global error_code
+    global total_tokens
 
     lexer = <lexer_name>(str)
     lexer.removeErrorListeners()
@@ -171,6 +173,7 @@ def DoParse(str, input_name, row_number):
     start_time = datetime.now()
     tree = parser.<start_symbol>()
     end_time = datetime.now()
+    total_tokens += len(tokens.tokens)
     diff = end_time - start_time
     diff_time = diff.total_seconds()
     result = ''

--- a/src/trgen/templates/Python3/st.Test.py
+++ b/src/trgen/templates/Python3/st.Test.py
@@ -173,7 +173,8 @@ def DoParse(str, input_name, row_number):
     start_time = datetime.now()
     tree = parser.<start_symbol>()
     end_time = datetime.now()
-    total_tokens += len(tokens.tokens)
+    token_count = len(tokens.tokens)
+    total_tokens += token_count
     diff = end_time - start_time
     diff_time = diff.total_seconds()
     result = ''
@@ -199,7 +200,9 @@ def DoParse(str, input_name, row_number):
         sys.stderr.write(result)
         sys.stderr.write(' ')
         sys.stderr.write(f'{diff_time}')
-        sys.stderr.write('\n')
+        sys.stderr.write(' s ')
+        sys.stderr.write(f'{int(token_count / diff_time) if diff_time > 0 else 0}')
+        sys.stderr.write(' tps\n')
     if (tee):
         output.close()
 

--- a/src/trgen/templates/Rust/src/st.main.rs
+++ b/src/trgen/templates/Rust/src/st.main.rs
@@ -95,10 +95,11 @@ fn parse_input(
     }
 
     if !flags.quiet {
-        eprint!("{}Rust {} {} {} {:.3}\n",
+        eprint!("{}Rust {} {} {} {:.3} s {:.0} tps\n",
             flags.prefix, idx, input_name,
             if error_cnt > 0 { "fail" } else { "success" },
-            elapsed.as_secs_f64()
+            elapsed.as_secs_f64(),
+            token_count as f64 / elapsed.as_secs_f64()
         );
     }
 

--- a/src/trgen/templates/Rust/src/st.main.rs
+++ b/src/trgen/templates/Rust/src/st.main.rs
@@ -27,7 +27,7 @@ fn parse_input(
     input_name: &str,
     idx: i32,
     flags: &Flags,
-) -> usize {
+) -> (usize, usize) {
         let writer: Rc\<RefCell\<Box\<dyn Write>>> = Rc::new(RefCell::new(
                 if flags.tee {
                         Box::new(File::create(format!("{}.errors", input_name)).unwrap()) as Box\<dyn Write>
@@ -80,6 +80,7 @@ fn parse_input(
     let start = Instant::now();
     let tree = parser.<start_symbol>().expect("parsing failed setup");
     let elapsed = start.elapsed();
+    let token_count = parser.get_input_stream_mut().size() as usize;
 
     let error_cnt = *lec.borrow() + *pec.borrow();
 
@@ -101,7 +102,7 @@ fn parse_input(
         );
     }
 
-    if error_cnt > 0 { 1 } else { 0 }
+    if error_cnt > 0 { (1, token_count) } else { (0, token_count) }
 }
 
 struct Flags {
@@ -167,16 +168,19 @@ fn main() {
             process::exit(1);
     } else {
         let mut exit_code = 0;
+        let mut total_tokens: usize = 0;
         let start_all = Instant::now();
         for (idx, input) in flags.inputs.iter().enumerate() {
-            let rc = parse_input(input, idx as i32, &flags);
+            let (rc, tc) = parse_input(input, idx as i32, &flags);
+            total_tokens += tc;
             if rc > 0 {
                 exit_code = 1;
             }
         }
         let elapsed = start_all.elapsed();
         if !flags.quiet {
-            eprintln!("{}Total Time: {:.3}", flags.prefix, elapsed.as_secs_f64());
+            let secs = elapsed.as_secs_f64();
+            eprintln!("{}Total Time: {:.3} Tokens per second: {:.0}", flags.prefix, secs, total_tokens as f64 / secs);
         }
         process::exit(exit_code as i32);
     }

--- a/src/trgen/templates/TypeScript/st.Test.ts
+++ b/src/trgen/templates/TypeScript/st.Test.ts
@@ -178,7 +178,8 @@ function DoParse(str: CharStream, input_name: string, row_number: number) {
     timer.start();
     const tree = parser.<start_symbol>();
     timer.stop();
-    total_tokens += tokens.size;
+    var token_count = tokens.size;
+    total_tokens += token_count;
     var result = "";
     if (listener_parser.had_error || listener_lexer.had_error) {
         result = 'fail';
@@ -196,7 +197,7 @@ function DoParse(str: CharStream, input_name: string, row_number: number) {
         }
     }
     if (!quiet) {
-        console.error(prefix + 'TypeScript ' + row_number + ' ' + input_name + ' ' + result + ' ' + t);
+        console.error(prefix + 'TypeScript ' + row_number + ' ' + input_name + ' ' + result + ' ' + t + ' s ' + Math.round(token_count / t) + ' tps');
     }
     if (tee) {
         closeSync(output);

--- a/src/trgen/templates/TypeScript/st.Test.ts
+++ b/src/trgen/templates/TypeScript/st.Test.ts
@@ -47,6 +47,7 @@ var enc = '<file_encoding>';
 var binary = <binary>;
 var string_instance = 0;
 var prefix = '';
+var total_tokens = 0;
 var inputs: string[] = [];
 var is_fns: boolean[] = [];
 
@@ -118,7 +119,7 @@ function main() {
         }
         timer.stop();
         var t = timer.time().m * 60 + timer.time().s + timer.time().ms / 1000;
-        if (!quiet) console.error(prefix + 'Total Time: ' + t);
+        if (!quiet) console.error(prefix + 'Total Time: ' + t + ' Tokens per second: ' + Math.round(total_tokens / t));
     }
     process.exitCode = error_code;
 }
@@ -177,6 +178,7 @@ function DoParse(str: CharStream, input_name: string, row_number: number) {
     timer.start();
     const tree = parser.<start_symbol>();
     timer.stop();
+    total_tokens += tokens.size;
     var result = "";
     if (listener_parser.had_error || listener_lexer.had_error) {
         result = 'fail';

--- a/src/trgen/templates/TypeScript/st.package.json
+++ b/src/trgen/templates/TypeScript/st.package.json
@@ -9,7 +9,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "antlr4": "<if(antlr_is_dev)>*<else><antlr_version><endif>",
+    "antlr4": "<if(antlr_is_dev)>*<else>4.13.2<endif>",
     "buffer": "^6.0.3",
     "fs-extra": "^11.1.1",
     "timer-node": "^5.0.6",

--- a/src/trgen/trgen.csproj
+++ b/src/trgen/trgen.csproj
@@ -19,7 +19,7 @@ This program is part of the Trash toolkit.]]>
 		<PublishRepositoryUrl>true</PublishRepositoryUrl>
 		<DebugType>portable</DebugType>
 		<DebugSymbols>true</DebugSymbols>
-		<Version>1.0.0</Version>
+		<Version>1.1.0</Version>
 		<RepositoryUrl>https://github.com/kaby76/Trash/tree/main/src/trgen</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
 	</PropertyGroup>

--- a/src/trgenvsc/Config.cs
+++ b/src/trgenvsc/Config.cs
@@ -23,6 +23,6 @@ namespace Trash
         public static readonly Config DEFAULT = new Config();
 
 	[Option("version", Required = false)]
-	public string Version { get; set; } = "1.0.0";
+	public string Version { get; set; } = "1.1.0";
     }
 }

--- a/src/trgenvsc/readme.md
+++ b/src/trgenvsc/readme.md
@@ -30,7 +30,7 @@ the XPath patterns to match certain parse trees.
 
 ## Current version
 
-1.0.0 Unified dispatcher for the Trash toolkit.
+1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github.
 
 ## License
 

--- a/src/trgenvsc/readme.md
+++ b/src/trgenvsc/readme.md
@@ -30,7 +30,7 @@ the XPath patterns to match certain parse trees.
 
 ## Current version
 
-1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github.
+1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github. Add tokens per second perf measurement.
 
 ## License
 

--- a/src/trgenvsc/trgenvsc.csproj
+++ b/src/trgenvsc/trgenvsc.csproj
@@ -19,7 +19,7 @@ This program is part of the Trash toolkit.]]>
 		<PublishRepositoryUrl>true</PublishRepositoryUrl>
 		<DebugType>portable</DebugType>
 		<DebugSymbols>true</DebugSymbols>
-		<Version>1.0.0</Version>
+		<Version>1.1.0</Version>
 		<RepositoryUrl>https://github.com/kaby76/Trash/tree/main/src/trgenvsc</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
 	</PropertyGroup>

--- a/src/trglob/Config.cs
+++ b/src/trglob/Config.cs
@@ -12,7 +12,7 @@ public class Config
     public bool Full { get; set; }
 
     [Option("version", Required = false)]
-    public string Version { get; set; } = "1.0.0";
+    public string Version { get; set; } = "1.1.0";
 
     [Value(0)] public IEnumerable<string> Files { get; set; }
 

--- a/src/trglob/readme.md
+++ b/src/trglob/readme.md
@@ -17,7 +17,7 @@ Expand a glob string into file names.
 
 ## Current version
 
-1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github.
+1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github. Add tokens per second perf measurement.
 
 ## License
 

--- a/src/trglob/readme.md
+++ b/src/trglob/readme.md
@@ -17,7 +17,7 @@ Expand a glob string into file names.
 
 ## Current version
 
-1.0.0 Unified dispatcher for the Trash toolkit.
+1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github.
 
 ## License
 

--- a/src/trglob/trglob.csproj
+++ b/src/trglob/trglob.csproj
@@ -19,7 +19,7 @@ This program is part of the Trash toolkit.]]>
 		<PublishRepositoryUrl>true</PublishRepositoryUrl>
 		<DebugType>portable</DebugType>
 		<DebugSymbols>true</DebugSymbols>
-		<Version>1.0.0</Version>
+		<Version>1.1.0</Version>
 		<RepositoryUrl>https://github.com/kaby76/Trash/tree/main/src/trglob</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
 	</PropertyGroup>

--- a/src/trgroup/Config.cs
+++ b/src/trgroup/Config.cs
@@ -15,7 +15,7 @@ namespace Trash
         public bool Verbose { get; set; }
 
 	[Option("version", Required = false)]
-	public string Version { get; set; } = "1.0.0";
+	public string Version { get; set; } = "1.1.0";
 
         [Value(0)]
         public IEnumerable<string> Expr { get; set; }

--- a/src/trgroup/readme.md
+++ b/src/trgroup/readme.md
@@ -56,7 +56,7 @@ XPaths, type _export MSYS2_ARG_CONV_EXCL="*"_, then execute your command.
 
 ## Current version
 
-1.0.0 Unified dispatcher for the Trash toolkit.
+1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github.
 
 ## License
 

--- a/src/trgroup/readme.md
+++ b/src/trgroup/readme.md
@@ -56,7 +56,7 @@ XPaths, type _export MSYS2_ARG_CONV_EXCL="*"_, then execute your command.
 
 ## Current version
 
-1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github.
+1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github. Add tokens per second perf measurement.
 
 ## License
 

--- a/src/trgroup/trgroup.csproj
+++ b/src/trgroup/trgroup.csproj
@@ -18,7 +18,7 @@ This program is part of the Trash toolkit.]]>
 		<PublishRepositoryUrl>true</PublishRepositoryUrl>
 		<DebugType>portable</DebugType>
 		<DebugSymbols>true</DebugSymbols>
-		<Version>1.0.0</Version>
+		<Version>1.1.0</Version>
 		<RepositoryUrl>https://github.com/kaby76/Trash/tree/main/src/trgroup</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
 	</PropertyGroup>

--- a/src/triconv/Config.cs
+++ b/src/triconv/Config.cs
@@ -12,7 +12,7 @@ public class Config
     public string ToCode { get; set; }
 
     [Option("version", Required = false)]
-    public string Version { get; set; } = "1.0.0";
+    public string Version { get; set; } = "1.1.0";
 
     [Value(0)] public IEnumerable<string> Files { get; set; }
 }

--- a/src/triconv/readme.md
+++ b/src/triconv/readme.md
@@ -20,7 +20,7 @@ unicode.
 
 ## Current version
 
-1.0.0 Unified dispatcher for the Trash toolkit.
+1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github.
 
 ## License
 

--- a/src/triconv/readme.md
+++ b/src/triconv/readme.md
@@ -20,7 +20,7 @@ unicode.
 
 ## Current version
 
-1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github.
+1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github. Add tokens per second perf measurement.
 
 ## License
 

--- a/src/triconv/triconv.csproj
+++ b/src/triconv/triconv.csproj
@@ -18,7 +18,7 @@ This program is part of the Trash toolkit.]]>
 		<PublishRepositoryUrl>true</PublishRepositoryUrl>
 		<DebugType>portable</DebugType>
 		<DebugSymbols>true</DebugSymbols>
-		<Version>1.0.0</Version>
+		<Version>1.1.0</Version>
 		<RepositoryUrl>https://github.com/kaby76/Trash/tree/main/src/trxml2</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
 	</PropertyGroup>

--- a/src/tritext/Config.cs
+++ b/src/tritext/Config.cs
@@ -19,5 +19,5 @@ public class Config
     public string Filter { get; set; } = "";
 
     [Option("version", Required = false)]
-    public string Version { get; set; } = "1.0.0";
+    public string Version { get; set; } = "1.1.0";
 }

--- a/src/tritext/readme.md
+++ b/src/tritext/readme.md
@@ -18,7 +18,7 @@ Get strings from a PDF file using IText.
 
 ## Current version
 
-1.0.0 Unified dispatcher for the Trash toolkit.
+1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github.
 
 ## License
 

--- a/src/tritext/readme.md
+++ b/src/tritext/readme.md
@@ -18,7 +18,7 @@ Get strings from a PDF file using IText.
 
 ## Current version
 
-1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github.
+1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github. Add tokens per second perf measurement.
 
 ## License
 

--- a/src/tritext/tritext.csproj
+++ b/src/tritext/tritext.csproj
@@ -19,7 +19,7 @@ This program is part of the Trash toolkit.
 		<PublishRepositoryUrl>true</PublishRepositoryUrl>
 		<DebugType>portable</DebugType>
 		<DebugSymbols>true</DebugSymbols>
-		<Version>1.0.0</Version>
+		<Version>1.1.0</Version>
 		<RepositoryUrl>https://github.com/kaby76/Trash/tree/main/src/tritext</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
 	</PropertyGroup>

--- a/src/trjson/Config.cs
+++ b/src/trjson/Config.cs
@@ -11,5 +11,5 @@ public class Config
     public bool Verbose { get; set; }
 
     [Option("version", Required = false)]
-    public string Version { get; set; } = "1.0.0";
+    public string Version { get; set; } = "1.1.0";
 }

--- a/src/trjson/readme.md
+++ b/src/trjson/readme.md
@@ -18,7 +18,7 @@ Read a parse tree from stdin and write a JSON represenation of it.
 
 ## Current version
 
-1.0.0 Unified dispatcher for the Trash toolkit.
+1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github.
 
 ## License
 

--- a/src/trjson/readme.md
+++ b/src/trjson/readme.md
@@ -18,7 +18,7 @@ Read a parse tree from stdin and write a JSON represenation of it.
 
 ## Current version
 
-1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github.
+1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github. Add tokens per second perf measurement.
 
 ## License
 

--- a/src/trjson/trjson.csproj
+++ b/src/trjson/trjson.csproj
@@ -19,7 +19,7 @@ This program is part of the Trash toolkit.
 		<PublishRepositoryUrl>true</PublishRepositoryUrl>
 		<DebugType>portable</DebugType>
 		<DebugSymbols>true</DebugSymbols>
-		<Version>1.0.0</Version>
+		<Version>1.1.0</Version>
 		<RepositoryUrl>https://github.com/kaby76/Trash/tree/main/src/trjson</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
 	</PropertyGroup>

--- a/src/trkleene/Config.cs
+++ b/src/trkleene/Config.cs
@@ -15,7 +15,7 @@ namespace Trash
         public bool Verbose { get; set; }
 
 	[Option("version", Required = false)]
-	public string Version { get; set; } = "1.0.0";
+	public string Version { get; set; } = "1.1.0";
 
         [Value(0)]
         public IEnumerable<string> Expr { get; set; }

--- a/src/trkleene/readme.md
+++ b/src/trkleene/readme.md
@@ -38,7 +38,7 @@ XPaths, type _export MSYS2_ARG_CONV_EXCL="*"_, then execute your command.
 
 ## Current version
 
-1.0.0 Unified dispatcher for the Trash toolkit.
+1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github.
 
 ## License
 

--- a/src/trkleene/readme.md
+++ b/src/trkleene/readme.md
@@ -38,7 +38,7 @@ XPaths, type _export MSYS2_ARG_CONV_EXCL="*"_, then execute your command.
 
 ## Current version
 
-1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github.
+1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github. Add tokens per second perf measurement.
 
 ## License
 

--- a/src/trkleene/trkleene.csproj
+++ b/src/trkleene/trkleene.csproj
@@ -20,7 +20,7 @@ This program is part of the Trash toolkit.
 		<PublishRepositoryUrl>true</PublishRepositoryUrl>
 		<DebugType>portable</DebugType>
 		<DebugSymbols>true</DebugSymbols>
-		<Version>1.0.0</Version>
+		<Version>1.1.0</Version>
 		<RepositoryUrl>https://github.com/kaby76/Trash/tree/main/src/trkleene</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
 	</PropertyGroup>

--- a/src/trnullable/Config.cs
+++ b/src/trnullable/Config.cs
@@ -11,5 +11,5 @@ public class Config
     public bool Verbose { get; set; }
 
     [Option("version", Required = false)]
-    public string Version { get; set; } = "1.0.0";
+    public string Version { get; set; } = "1.1.0";
 }

--- a/src/trnullable/readme.md
+++ b/src/trnullable/readme.md
@@ -18,7 +18,7 @@ trparse A.g4 | trnullable
 
 ## Current version
 
-1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github.
+1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github. Add tokens per second perf measurement.
 
 ## License
 

--- a/src/trnullable/readme.md
+++ b/src/trnullable/readme.md
@@ -18,7 +18,7 @@ trparse A.g4 | trnullable
 
 ## Current version
 
-1.0.0 Unified dispatcher for the Trash toolkit.
+1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github.
 
 ## License
 

--- a/src/trnullable/trnullable.csproj
+++ b/src/trnullable/trnullable.csproj
@@ -19,7 +19,7 @@ This program is part of the Trash toolkit.
 		<PublishRepositoryUrl>true</PublishRepositoryUrl>
 		<DebugType>portable</DebugType>
 		<DebugSymbols>true</DebugSymbols>
-		<Version>1.0.0</Version>
+		<Version>1.1.0</Version>
 		<RepositoryUrl>https://github.com/kaby76/Trash/tree/main/src/trnullable</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
 	</PropertyGroup>

--- a/src/trparse/Config.cs
+++ b/src/trparse/Config.cs
@@ -42,7 +42,7 @@ public class Config
     public bool Verbose { get; set; }
 
     [Option("version", Required = false)]
-    public string Version { get; set; } = "1.0.0";
+    public string Version { get; set; } = "1.1.0";
 
     [Option('x', Required = false, HelpText = "Read input file names from stdin.")]
     public bool ReadFileNameStdin { get; set; }

--- a/src/trparse/readme.md
+++ b/src/trparse/readme.md
@@ -50,7 +50,7 @@ the `--type` command-line option:
 
 ## Current version
 
-1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github.
+1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github. Add tokens per second perf measurement.
 
 ## License
 

--- a/src/trparse/readme.md
+++ b/src/trparse/readme.md
@@ -50,7 +50,7 @@ the `--type` command-line option:
 
 ## Current version
 
-1.0.0 Unified dispatcher for the Trash toolkit.
+1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github.
 
 ## License
 

--- a/src/trparse/trparse.csproj
+++ b/src/trparse/trparse.csproj
@@ -19,7 +19,7 @@ This program is part of the Trash toolkit.]]>
 		<PublishRepositoryUrl>true</PublishRepositoryUrl>
 		<DebugType>portable</DebugType>
 		<DebugSymbols>true</DebugSymbols>
-		<Version>1.0.0</Version>
+		<Version>1.1.0</Version>
 		<RepositoryUrl>https://github.com/kaby76/Trash/tree/main/src/trparse</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
 	</PropertyGroup>

--- a/src/trperf/Config.cs
+++ b/src/trperf/Config.cs
@@ -33,5 +33,5 @@ public class Config
     public bool ReadFileNameStdin { get; set; }
 
     [Option("version", Required = false)]
-    public string Version { get; set; } = "1.0.0";
+    public string Version { get; set; } = "1.1.0";
 }

--- a/src/trperf/readme.md
+++ b/src/trperf/readme.md
@@ -67,7 +67,7 @@ be in a trgen-generated parser directory, or use the -p option.
 
 ## Current version
 
-1.0.0 Unified dispatcher for the Trash toolkit.
+1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github.
 
 ## License
 

--- a/src/trperf/readme.md
+++ b/src/trperf/readme.md
@@ -67,7 +67,7 @@ be in a trgen-generated parser directory, or use the -p option.
 
 ## Current version
 
-1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github.
+1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github. Add tokens per second perf measurement.
 
 ## License
 

--- a/src/trperf/trperf.csproj
+++ b/src/trperf/trperf.csproj
@@ -20,7 +20,7 @@ This program is part of the Trash toolkit.]]>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <DebugType>portable</DebugType>
     <DebugSymbols>true</DebugSymbols>
-    <Version>1.0.0</Version>
+    <Version>1.1.0</Version>
     <RepositoryUrl>https://github.com/kaby76/Trash/tree/main/src/trperf</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
   </PropertyGroup>

--- a/src/trpiggy/Config.cs
+++ b/src/trpiggy/Config.cs
@@ -15,6 +15,6 @@ namespace Trash
         public bool Verbose { get; set; }
 
 	[Option("version", Required = false)]
-	public string Version { get; set; } = "1.0.0";
+	public string Version { get; set; } = "1.1.0";
     }
 }

--- a/src/trpiggy/readme.md
+++ b/src/trpiggy/readme.md
@@ -63,7 +63,7 @@ Output:
 
 ## Current version
 
-1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github.
+1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github. Add tokens per second perf measurement.
 
 ## License
 

--- a/src/trpiggy/readme.md
+++ b/src/trpiggy/readme.md
@@ -63,7 +63,7 @@ Output:
 
 ## Current version
 
-1.0.0 Unified dispatcher for the Trash toolkit.
+1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github.
 
 ## License
 

--- a/src/trpiggy/trpiggy.csproj
+++ b/src/trpiggy/trpiggy.csproj
@@ -19,7 +19,7 @@ This program is part of the Trash toolkit.]]>
 		<PublishRepositoryUrl>true</PublishRepositoryUrl>
 		<DebugType>portable</DebugType>
 		<DebugSymbols>true</DebugSymbols>
-		<Version>1.0.0</Version>
+		<Version>1.1.0</Version>
 		<RepositoryUrl>https://github.com/kaby76/Trash/tree/main/src/trpiggy</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
 	</PropertyGroup>

--- a/src/trquery/Config.cs
+++ b/src/trquery/Config.cs
@@ -22,7 +22,7 @@ public class Config
     public bool Verbose { get; set; }
 
     [Option("version", Required = false)]
-    public string Version { get; set; } = "1.0.0";
+    public string Version { get; set; } = "1.1.0";
 
     [Value(0)] public IEnumerable<string> Query { get; set; }
 }

--- a/src/trquery/readme.md
+++ b/src/trquery/readme.md
@@ -47,7 +47,7 @@ XPaths, type _export MSYS2_ARG_CONV_EXCL="*"_, then execute your command.
 
 ## Current version
 
-1.0.0 Unified dispatcher for the Trash toolkit.
+1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github.
 
 ## License
 

--- a/src/trquery/readme.md
+++ b/src/trquery/readme.md
@@ -47,7 +47,7 @@ XPaths, type _export MSYS2_ARG_CONV_EXCL="*"_, then execute your command.
 
 ## Current version
 
-1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github.
+1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github. Add tokens per second perf measurement.
 
 ## License
 

--- a/src/trquery/trquery.csproj
+++ b/src/trquery/trquery.csproj
@@ -18,7 +18,7 @@ This program is part of the Trash toolkit.]]>
 		<PublishRepositoryUrl>true</PublishRepositoryUrl>
 		<DebugType>portable</DebugType>
 		<DebugSymbols>true</DebugSymbols>
-		<Version>1.0.0</Version>
+		<Version>1.1.0</Version>
 		<RepositoryUrl>https://github.com/kaby76/Trash/tree/main/src/trquery</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
 	</PropertyGroup>

--- a/src/trrename/Config.cs
+++ b/src/trrename/Config.cs
@@ -23,5 +23,5 @@ public class Config
     public bool Verbose { get; set; }
 
     [Option("version", Required = false)]
-    public string Version { get; set; } = "1.0.0";
+    public string Version { get; set; } = "1.1.0";
 }

--- a/src/trrename/readme.md
+++ b/src/trrename/readme.md
@@ -27,7 +27,7 @@ make sure to enclose the argument as it contains semi-colons.
 
 ## Current version
 
-1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github.
+1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github. Add tokens per second perf measurement.
 
 ## License
 

--- a/src/trrename/readme.md
+++ b/src/trrename/readme.md
@@ -27,7 +27,7 @@ make sure to enclose the argument as it contains semi-colons.
 
 ## Current version
 
-1.0.0 Unified dispatcher for the Trash toolkit.
+1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github.
 
 ## License
 

--- a/src/trrename/trrename.csproj
+++ b/src/trrename/trrename.csproj
@@ -18,7 +18,7 @@ This program is part of the Trash toolkit.]]>
 		<PublishRepositoryUrl>true</PublishRepositoryUrl>
 		<DebugType>portable</DebugType>
 		<DebugSymbols>true</DebugSymbols>
-		<Version>1.0.0</Version>
+		<Version>1.1.0</Version>
 		<RepositoryUrl>https://github.com/kaby76/Trash/tree/main/src/trrename</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
 	</PropertyGroup>

--- a/src/trrr/Config.cs
+++ b/src/trrr/Config.cs
@@ -15,7 +15,7 @@ namespace Trash
         public bool Verbose { get; set; }
 
 	[Option("version", Required = false)]
-	public string Version { get; set; } = "1.0.0";
+	public string Version { get; set; } = "1.1.0";
 
         [Value(0, Required = false)]
         public string Expr { get; set; }

--- a/src/trrr/readme.md
+++ b/src/trrr/readme.md
@@ -14,7 +14,7 @@
 
 ## Current version
 
-1.0.0 Unified dispatcher for the Trash toolkit.
+1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github.
 
 ## License
 

--- a/src/trrr/readme.md
+++ b/src/trrr/readme.md
@@ -14,7 +14,7 @@
 
 ## Current version
 
-1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github.
+1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github. Add tokens per second perf measurement.
 
 ## License
 

--- a/src/trrr/trrr.csproj
+++ b/src/trrr/trrr.csproj
@@ -18,7 +18,7 @@ This program is part of the Trash toolkit.]]>
 		<PublishRepositoryUrl>true</PublishRepositoryUrl>
 		<DebugType>portable</DebugType>
 		<DebugSymbols>true</DebugSymbols>
-		<Version>1.0.0</Version>
+		<Version>1.1.0</Version>
 		<RepositoryUrl>https://github.com/kaby76/Trash/tree/main/src/trrr</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
 	</PropertyGroup>

--- a/src/trrup/Config.cs
+++ b/src/trrup/Config.cs
@@ -15,6 +15,6 @@ namespace Trash
         public bool Verbose { get; set; }
 
 	[Option("version", Required = false)]
-	public string Version { get; set; } = "1.0.0";
+	public string Version { get; set; } = "1.1.0";
     }
 }

--- a/src/trrup/readme.md
+++ b/src/trrup/readme.md
@@ -42,7 +42,7 @@ XPaths, type _export MSYS2_ARG_CONV_EXCL="*"_, then execute your command.
 
 ## Current version
 
-1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github.
+1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github. Add tokens per second perf measurement.
 
 ## License
 

--- a/src/trrup/readme.md
+++ b/src/trrup/readme.md
@@ -42,7 +42,7 @@ XPaths, type _export MSYS2_ARG_CONV_EXCL="*"_, then execute your command.
 
 ## Current version
 
-1.0.0 Unified dispatcher for the Trash toolkit.
+1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github.
 
 ## License
 

--- a/src/trrup/trrup.csproj
+++ b/src/trrup/trrup.csproj
@@ -18,7 +18,7 @@ This program is part of the Trash toolkit.]]>
 		<PublishRepositoryUrl>true</PublishRepositoryUrl>
 		<DebugType>portable</DebugType>
 		<DebugSymbols>true</DebugSymbols>
-		<Version>1.0.0</Version>
+		<Version>1.1.0</Version>
 		<RepositoryUrl>https://github.com/kaby76/Trash/tree/main/src/trrup</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
 	</PropertyGroup>

--- a/src/trsem/Config.cs
+++ b/src/trsem/Config.cs
@@ -21,6 +21,6 @@ namespace Trash
         public bool Verbose { get; set; }
 
 	[Option("version", Required = false)]
-	public string Version { get; set; } = "1.0.0";
+	public string Version { get; set; } = "1.1.0";
     }
 }

--- a/src/trsem/readme.md
+++ b/src/trsem/readme.md
@@ -18,7 +18,7 @@ Read a static semantics spec file and generate code.
 
 ## Current version
 
-1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github.
+1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github. Add tokens per second perf measurement.
 
 ## License
 

--- a/src/trsem/readme.md
+++ b/src/trsem/readme.md
@@ -18,7 +18,7 @@ Read a static semantics spec file and generate code.
 
 ## Current version
 
-1.0.0 Unified dispatcher for the Trash toolkit.
+1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github.
 
 ## License
 

--- a/src/trsem/trsem.csproj
+++ b/src/trsem/trsem.csproj
@@ -19,7 +19,7 @@ This program is part of the Trash toolkit.]]>
 		<PublishRepositoryUrl>true</PublishRepositoryUrl>
 		<DebugType>portable</DebugType>
 		<DebugSymbols>true</DebugSymbols>
-		<Version>1.0.0</Version>
+		<Version>1.1.0</Version>
 		<RepositoryUrl>https://github.com/kaby76/Trash/tree/main/src/trsem</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
 	</PropertyGroup>

--- a/src/trsort/Config.cs
+++ b/src/trsort/Config.cs
@@ -30,6 +30,6 @@ namespace Trash
         public bool Verbose { get; set; }
 
 	[Option("version", Required = false)]
-	public string Version { get; set; } = "1.0.0";
+	public string Version { get; set; } = "1.1.0";
     }
 }

--- a/src/trsort/readme.md
+++ b/src/trsort/readme.md
@@ -37,7 +37,7 @@ XPaths, type _export MSYS2_ARG_CONV_EXCL="*"_, then execute your command.
 
 ## Current version
 
-1.0.0 Unified dispatcher for the Trash toolkit.
+1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github.
 
 ## License
 

--- a/src/trsort/readme.md
+++ b/src/trsort/readme.md
@@ -37,7 +37,7 @@ XPaths, type _export MSYS2_ARG_CONV_EXCL="*"_, then execute your command.
 
 ## Current version
 
-1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github.
+1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github. Add tokens per second perf measurement.
 
 ## License
 

--- a/src/trsort/trsort.csproj
+++ b/src/trsort/trsort.csproj
@@ -18,7 +18,7 @@ This program is part of the Trash toolkit.]]>
 		<PublishRepositoryUrl>true</PublishRepositoryUrl>
 		<DebugType>portable</DebugType>
 		<DebugSymbols>true</DebugSymbols>
-		<Version>1.0.0</Version>
+		<Version>1.1.0</Version>
 		<RepositoryUrl>https://github.com/kaby76/Trash/tree/main/src/trsort</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
 	</PropertyGroup>

--- a/src/trsplit/Config.cs
+++ b/src/trsplit/Config.cs
@@ -15,5 +15,5 @@ public class Config
     public bool Verbose { get; set; }
 
     [Option("version", Required = false)]
-    public string Version { get; set; } = "1.0.0";
+    public string Version { get; set; } = "1.1.0";
 }

--- a/src/trsplit/readme.md
+++ b/src/trsplit/readme.md
@@ -45,7 +45,7 @@ modified.
 
 ## Current version
 
-1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github.
+1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github. Add tokens per second perf measurement.
 
 ## License
 

--- a/src/trsplit/readme.md
+++ b/src/trsplit/readme.md
@@ -45,7 +45,7 @@ modified.
 
 ## Current version
 
-1.0.0 Unified dispatcher for the Trash toolkit.
+1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github.
 
 ## License
 

--- a/src/trsplit/trsplit.csproj
+++ b/src/trsplit/trsplit.csproj
@@ -18,7 +18,7 @@ This program is part of the Trash toolkit.]]>
 		<PublishRepositoryUrl>true</PublishRepositoryUrl>
 		<DebugType>portable</DebugType>
 		<DebugSymbols>true</DebugSymbols>
-		<Version>1.0.0</Version>
+		<Version>1.1.0</Version>
 		<RepositoryUrl>https://github.com/kaby76/Trash/tree/main/src/trsplit</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
 	</PropertyGroup>

--- a/src/trsponge/Config.cs
+++ b/src/trsponge/Config.cs
@@ -17,5 +17,5 @@ public class Config
     public bool Verbose { get; set; }
 
     [Option("version", Required = false)]
-    public string Version { get; set; } = "1.0.0";
+    public string Version { get; set; } = "1.1.0";
 }

--- a/src/trsponge/readme.md
+++ b/src/trsponge/readme.md
@@ -19,7 +19,7 @@ results to file(s).
 
 ## Current version
 
-1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github.
+1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github. Add tokens per second perf measurement.
 
 ## License
 

--- a/src/trsponge/readme.md
+++ b/src/trsponge/readme.md
@@ -19,7 +19,7 @@ results to file(s).
 
 ## Current version
 
-1.0.0 Unified dispatcher for the Trash toolkit.
+1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github.
 
 ## License
 

--- a/src/trsponge/trsponge.csproj
+++ b/src/trsponge/trsponge.csproj
@@ -18,7 +18,7 @@ This program is part of the Trash toolkit.]]>
 		<PublishRepositoryUrl>true</PublishRepositoryUrl>
 		<DebugType>portable</DebugType>
 		<DebugSymbols>true</DebugSymbols>
-		<Version>1.0.0</Version>
+		<Version>1.1.0</Version>
 		<RepositoryUrl>https://github.com/kaby76/Trash/tree/main/src/trsponge</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
 	</PropertyGroup>

--- a/src/trtext/Config.cs
+++ b/src/trtext/Config.cs
@@ -24,5 +24,5 @@ public class Config
     public bool Count { get; set; }
 
     [Option("version", Required = false)]
-    public string Version { get; set; } = "1.0.0";
+    public string Version { get; set; } = "1.1.0";
 }

--- a/src/trtext/readme.md
+++ b/src/trtext/readme.md
@@ -19,7 +19,7 @@ specified, the line number range for the tree is printed.
 
 ## Current version
 
-1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github.
+1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github. Add tokens per second perf measurement.
 
 ## License
 

--- a/src/trtext/readme.md
+++ b/src/trtext/readme.md
@@ -19,7 +19,7 @@ specified, the line number range for the tree is printed.
 
 ## Current version
 
-1.0.0 Unified dispatcher for the Trash toolkit.
+1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github.
 
 ## License
 

--- a/src/trtext/trtext.csproj
+++ b/src/trtext/trtext.csproj
@@ -20,7 +20,7 @@ This program is part of the Trash toolkit.
 		<PublishRepositoryUrl>true</PublishRepositoryUrl>
 		<DebugType>portable</DebugType>
 		<DebugSymbols>true</DebugSymbols>
-		<Version>1.0.0</Version>
+		<Version>1.1.0</Version>
 		<RepositoryUrl>https://github.com/kaby76/Trash/tree/main/src/trtext</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
 	</PropertyGroup>

--- a/src/trthompson/Config.cs
+++ b/src/trthompson/Config.cs
@@ -12,6 +12,6 @@ namespace Trash
         public bool Verbose { get; set; }
 
 	[Option("version", Required = false)]
-	public string Version { get; set; } = "1.0.0";
+	public string Version { get; set; } = "1.1.0";
     }
 }

--- a/src/trthompson/readme.md
+++ b/src/trthompson/readme.md
@@ -12,7 +12,7 @@
 
 ## Current version
 
-1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github.
+1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github. Add tokens per second perf measurement.
 
 ## License
 

--- a/src/trthompson/readme.md
+++ b/src/trthompson/readme.md
@@ -12,7 +12,7 @@
 
 ## Current version
 
-1.0.0 Unified dispatcher for the Trash toolkit.
+1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github.
 
 ## License
 

--- a/src/trthompson/trthompson.csproj
+++ b/src/trthompson/trthompson.csproj
@@ -19,7 +19,7 @@ This program is part of the Trash toolkit.
 		<PublishRepositoryUrl>true</PublishRepositoryUrl>
 		<DebugType>portable</DebugType>
 		<DebugSymbols>true</DebugSymbols>
-		<Version>1.0.0</Version>
+		<Version>1.1.0</Version>
 		<RepositoryUrl>https://github.com/kaby76/Trash/tree/main/src/trthompson</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
 	</PropertyGroup>

--- a/src/trtokens/Config.cs
+++ b/src/trtokens/Config.cs
@@ -11,5 +11,5 @@ public class Config
     public bool Verbose { get; set; }
 
     [Option("version", Required = false)]
-    public string Version { get; set; } = "1.0.0";
+    public string Version { get; set; } = "1.1.0";
 }

--- a/src/trtokens/readme.md
+++ b/src/trtokens/readme.md
@@ -52,7 +52,7 @@ Output:
 
 ## Current version
 
-1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github.
+1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github. Add tokens per second perf measurement.
 
 ## License
 

--- a/src/trtokens/readme.md
+++ b/src/trtokens/readme.md
@@ -52,7 +52,7 @@ Output:
 
 ## Current version
 
-1.0.0 Unified dispatcher for the Trash toolkit.
+1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github.
 
 ## License
 

--- a/src/trtokens/trtokens.csproj
+++ b/src/trtokens/trtokens.csproj
@@ -18,7 +18,7 @@ This program is part of the Trash toolkit.]]>
 		<PublishRepositoryUrl>true</PublishRepositoryUrl>
 		<DebugType>portable</DebugType>
 		<DebugSymbols>true</DebugSymbols>
-		<Version>1.0.0</Version>
+		<Version>1.1.0</Version>
 		<RepositoryUrl>https://github.com/kaby76/Trash/tree/main/src/trtokens</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
 	</PropertyGroup>

--- a/src/trtree/Config.cs
+++ b/src/trtree/Config.cs
@@ -26,5 +26,5 @@ public class Config
     public bool BlockTreeStyle { get; set; }
 
     [Option("version", Required = false)]
-    public string Version { get; set; } = "1.0.0";
+    public string Version { get; set; } = "1.1.0";
 }

--- a/src/trtree/readme.md
+++ b/src/trtree/readme.md
@@ -18,7 +18,7 @@ Reads a tree from stdin and prints the tree as an indented node list.
 
 ## Current version
 
-1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github.
+1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github. Add tokens per second perf measurement.
 
 ## License
 

--- a/src/trtree/readme.md
+++ b/src/trtree/readme.md
@@ -18,7 +18,7 @@ Reads a tree from stdin and prints the tree as an indented node list.
 
 ## Current version
 
-1.0.0 Unified dispatcher for the Trash toolkit.
+1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github.
 
 ## License
 

--- a/src/trtree/trtree.csproj
+++ b/src/trtree/trtree.csproj
@@ -19,7 +19,7 @@ This program is part of the Trash toolkit.
 		<PublishRepositoryUrl>true</PublishRepositoryUrl>
 		<DebugType>portable</DebugType>
 		<DebugSymbols>true</DebugSymbols>
-		<Version>1.0.0</Version>
+		<Version>1.1.0</Version>
 		<RepositoryUrl>https://github.com/kaby76/Trash/tree/main/src/trtree</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
 	</PropertyGroup>

--- a/src/trull/Config.cs
+++ b/src/trull/Config.cs
@@ -15,7 +15,7 @@ namespace Trash
         public bool Verbose { get; set; }
 
 	[Option("version", Required = false)]
-	public string Version { get; set; } = "1.0.0";
+	public string Version { get; set; } = "1.1.0";
 
         [Value(0)]
         public IEnumerable<string> Expr { get; set; }

--- a/src/trull/readme.md
+++ b/src/trull/readme.md
@@ -63,7 +63,7 @@ XPaths, type _export MSYS2_ARG_CONV_EXCL="*"_, then execute your command.
 
 ## Current version
 
-1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github.
+1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github. Add tokens per second perf measurement.
 
 ## License
 

--- a/src/trull/readme.md
+++ b/src/trull/readme.md
@@ -63,7 +63,7 @@ XPaths, type _export MSYS2_ARG_CONV_EXCL="*"_, then execute your command.
 
 ## Current version
 
-1.0.0 Unified dispatcher for the Trash toolkit.
+1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github.
 
 ## License
 

--- a/src/trull/trull.csproj
+++ b/src/trull/trull.csproj
@@ -19,7 +19,7 @@ This program is part of the Trash toolkit.
 		<PublishRepositoryUrl>true</PublishRepositoryUrl>
 		<DebugType>portable</DebugType>
 		<DebugSymbols>true</DebugSymbols>
-		<Version>1.0.0</Version>
+		<Version>1.1.0</Version>
 		<RepositoryUrl>https://github.com/kaby76/Trash/tree/main/src/trull</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
 	</PropertyGroup>

--- a/src/trunfold/Config.cs
+++ b/src/trunfold/Config.cs
@@ -15,7 +15,7 @@ public class Config
     public bool Verbose { get; set; }
 
     [Option("version", Required = false)]
-    public string Version { get; set; } = "1.0.0";
+    public string Version { get; set; } = "1.1.0";
 
     [Value(0, Min = 1)] public IEnumerable<string> Expr { get; set; }
 }

--- a/src/trunfold/readme.md
+++ b/src/trunfold/readme.md
@@ -51,7 +51,7 @@ XPaths, type _export MSYS2_ARG_CONV_EXCL="*"_, then execute your command.
 
 ## Current version
 
-1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github.
+1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github. Add tokens per second perf measurement.
 
 ## License
 

--- a/src/trunfold/readme.md
+++ b/src/trunfold/readme.md
@@ -51,7 +51,7 @@ XPaths, type _export MSYS2_ARG_CONV_EXCL="*"_, then execute your command.
 
 ## Current version
 
-1.0.0 Unified dispatcher for the Trash toolkit.
+1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github.
 
 ## License
 

--- a/src/trunfold/trunfold.csproj
+++ b/src/trunfold/trunfold.csproj
@@ -19,7 +19,7 @@ in the parse tree. This program is part of the Trash toolkit.
 		<PublishRepositoryUrl>true</PublishRepositoryUrl>
 		<DebugType>portable</DebugType>
 		<DebugSymbols>true</DebugSymbols>
-		<Version>1.0.0</Version>
+		<Version>1.1.0</Version>
 		<RepositoryUrl>https://github.com/kaby76/Trash/tree/main/src/trunfold</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
 	</PropertyGroup>

--- a/src/trunfoldlit/Config.cs
+++ b/src/trunfoldlit/Config.cs
@@ -15,5 +15,5 @@ public class Config
     public bool Verbose { get; set; }
 
     [Option("version", Required = false)]
-    public string Version { get; set; } = "1.0.0";
+    public string Version { get; set; } = "1.1.0";
 }

--- a/src/trunfoldlit/readme.md
+++ b/src/trunfoldlit/readme.md
@@ -51,7 +51,7 @@ XPaths, type _export MSYS2_ARG_CONV_EXCL="*"_, then execute your command.
 
 ## Current version
 
-1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github.
+1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github. Add tokens per second perf measurement.
 
 ## License
 

--- a/src/trunfoldlit/readme.md
+++ b/src/trunfoldlit/readme.md
@@ -51,7 +51,7 @@ XPaths, type _export MSYS2_ARG_CONV_EXCL="*"_, then execute your command.
 
 ## Current version
 
-1.0.0 Unified dispatcher for the Trash toolkit.
+1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github.
 
 ## License
 

--- a/src/trunfoldlit/trunfoldlit.csproj
+++ b/src/trunfoldlit/trunfoldlit.csproj
@@ -19,7 +19,7 @@ in the parse tree. This program is part of the Trash toolkit.
 		<PublishRepositoryUrl>true</PublishRepositoryUrl>
 		<DebugType>portable</DebugType>
 		<DebugSymbols>true</DebugSymbols>
-		<Version>1.0.0</Version>
+		<Version>1.1.0</Version>
 		<RepositoryUrl>https://github.com/kaby76/Trash/tree/main/src/trunfoldlit</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
 	</PropertyGroup>

--- a/src/trungroup/Config.cs
+++ b/src/trungroup/Config.cs
@@ -15,7 +15,7 @@ public class Config
     public bool Verbose { get; set; }
 
     [Option("version", Required = false)]
-    public string Version { get; set; } = "1.0.0";
+    public string Version { get; set; } = "1.1.0";
 
     [Value(0, Min = 1)] public IEnumerable<string> Expr { get; set; }
 }

--- a/src/trungroup/readme.md
+++ b/src/trungroup/readme.md
@@ -24,7 +24,7 @@ XPaths, type _export MSYS2_ARG_CONV_EXCL="*"_, then execute your command.
 
 ## Current version
 
-1.0.0 Unified dispatcher for the Trash toolkit.
+1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github.
 
 ## License
 

--- a/src/trungroup/readme.md
+++ b/src/trungroup/readme.md
@@ -24,7 +24,7 @@ XPaths, type _export MSYS2_ARG_CONV_EXCL="*"_, then execute your command.
 
 ## Current version
 
-1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github.
+1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github. Add tokens per second perf measurement.
 
 ## License
 

--- a/src/trungroup/trungroup.csproj
+++ b/src/trungroup/trungroup.csproj
@@ -18,7 +18,7 @@ This program is part of the Trash toolkit.]]>
 		<PublishRepositoryUrl>true</PublishRepositoryUrl>
 		<DebugType>portable</DebugType>
 		<DebugSymbols>true</DebugSymbols>
-		<Version>1.0.0</Version>
+		<Version>1.1.0</Version>
 		<RepositoryUrl>https://github.com/kaby76/Trash/tree/main/src/trungroup</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
 	</PropertyGroup>

--- a/src/trwdog/Config.cs
+++ b/src/trwdog/Config.cs
@@ -11,5 +11,5 @@ public class Config
     public int? Timeout { get; set; }
 
     [Option("version", Required = false)]
-    public string Version { get; set; } = "1.0.0";
+    public string Version { get; set; } = "1.1.0";
 }

--- a/src/trwdog/readme.md
+++ b/src/trwdog/readme.md
@@ -18,7 +18,7 @@ Execute a command with a watchdog timer.
 
 ## Current version
 
-1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github.
+1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github. Add tokens per second perf measurement.
 
 ## License
 

--- a/src/trwdog/readme.md
+++ b/src/trwdog/readme.md
@@ -18,7 +18,7 @@ Execute a command with a watchdog timer.
 
 ## Current version
 
-1.0.0 Unified dispatcher for the Trash toolkit.
+1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github.
 
 ## License
 

--- a/src/trwdog/trwdog.csproj
+++ b/src/trwdog/trwdog.csproj
@@ -26,7 +26,7 @@ This program is part of the Trash toolkit.
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="System.Management" Version="10.0.8" />
+		<PackageReference Include="System.Management" Version="10.0.9" />
 		<PackageReference Include="CommandLineParser" Version="2.9.1" />
 	</ItemGroup>
 	<ItemGroup>

--- a/src/trwdog/trwdog.csproj
+++ b/src/trwdog/trwdog.csproj
@@ -20,7 +20,7 @@ This program is part of the Trash toolkit.
 		<PublishRepositoryUrl>true</PublishRepositoryUrl>
 		<DebugType>portable</DebugType>
 		<DebugSymbols>true</DebugSymbols>
-		<Version>1.0.0</Version>
+		<Version>1.1.0</Version>
 		<RepositoryUrl>https://github.com/kaby76/Trash/tree/main/src/trwdog</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
 	</PropertyGroup>

--- a/src/trxgrep/Config.cs
+++ b/src/trxgrep/Config.cs
@@ -18,7 +18,7 @@ public class Config
     public bool Verbose { get; set; }
 
     [Option("version", Required = false)]
-    public string Version { get; set; } = "1.0.0";
+    public string Version { get; set; } = "1.1.0";
 
     [Value(0, Min = 1)] public IEnumerable<string> Expr { get; set; }
 }

--- a/src/trxgrep/readme.md
+++ b/src/trxgrep/readme.md
@@ -24,7 +24,7 @@ XPaths, type _export MSYS2_ARG_CONV_EXCL="*"_, then execute your command.
 
 ## Current version
 
-1.0.0 Unified dispatcher for the Trash toolkit.
+1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github.
 
 ## License
 

--- a/src/trxgrep/readme.md
+++ b/src/trxgrep/readme.md
@@ -24,7 +24,7 @@ XPaths, type _export MSYS2_ARG_CONV_EXCL="*"_, then execute your command.
 
 ## Current version
 
-1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github.
+1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github. Add tokens per second perf measurement.
 
 ## License
 

--- a/src/trxgrep/trxgrep.csproj
+++ b/src/trxgrep/trxgrep.csproj
@@ -19,7 +19,7 @@ This program is part of the Trash toolkit.
 		<PublishRepositoryUrl>true</PublishRepositoryUrl>
 		<DebugType>portable</DebugType>
 		<DebugSymbols>true</DebugSymbols>
-		<Version>1.0.0</Version>
+		<Version>1.1.0</Version>
 		<RepositoryUrl>https://github.com/kaby76/Trash/tree/main/src/trxgrep</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
 	</PropertyGroup>

--- a/src/trxml/Config.cs
+++ b/src/trxml/Config.cs
@@ -11,5 +11,5 @@ public class Config
     public bool Verbose { get; set; }
 
     [Option("version", Required = false)]
-    public string Version { get; set; } = "1.0.0";
+    public string Version { get; set; } = "1.1.0";
 }

--- a/src/trxml/readme.md
+++ b/src/trxml/readme.md
@@ -18,7 +18,7 @@ Read a tree from stdin and write an XML represenation of it.
 
 ## Current version
 
-1.0.0 Unified dispatcher for the Trash toolkit.
+1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github.
 
 ## License
 

--- a/src/trxml/readme.md
+++ b/src/trxml/readme.md
@@ -18,7 +18,7 @@ Read a tree from stdin and write an XML represenation of it.
 
 ## Current version
 
-1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github.
+1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github. Add tokens per second perf measurement.
 
 ## License
 

--- a/src/trxml/trxml.csproj
+++ b/src/trxml/trxml.csproj
@@ -18,7 +18,7 @@ This program is part of the Trash toolkit.]]>
 		<PublishRepositoryUrl>true</PublishRepositoryUrl>
 		<DebugType>portable</DebugType>
 		<DebugSymbols>true</DebugSymbols>
-		<Version>1.0.0</Version>
+		<Version>1.1.0</Version>
 		<RepositoryUrl>https://github.com/kaby76/Trash/tree/main/src/trxml</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
 	</PropertyGroup>

--- a/src/trxml2/Config.cs
+++ b/src/trxml2/Config.cs
@@ -9,7 +9,7 @@ public class Config
     public bool Verbose { get; set; }
 
     [Option("version", Required = false)]
-    public string Version { get; set; } = "1.0.0";
+    public string Version { get; set; } = "1.1.0";
 
     [Value(0)] public IEnumerable<string> Files { get; set; }
 }

--- a/src/trxml2/readme.md
+++ b/src/trxml2/readme.md
@@ -18,7 +18,7 @@ Read an xml file and enumerate all paths to elements in xpath syntax.
 
 ## Current version
 
-1.0.0 Unified dispatcher for the Trash toolkit.
+1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github.
 
 ## License
 

--- a/src/trxml2/readme.md
+++ b/src/trxml2/readme.md
@@ -18,7 +18,7 @@ Read an xml file and enumerate all paths to elements in xpath syntax.
 
 ## Current version
 
-1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github.
+1.1.0 Unified dispatcher for the Trash toolkit. Fix broken Cpp target on Github. Add tokens per second perf measurement.
 
 ## License
 

--- a/src/trxml2/trxml2.csproj
+++ b/src/trxml2/trxml2.csproj
@@ -18,7 +18,7 @@ This program is part of the Trash toolkit.]]>
 		<PublishRepositoryUrl>true</PublishRepositoryUrl>
 		<DebugType>portable</DebugType>
 		<DebugSymbols>true</DebugSymbols>
-		<Version>1.0.0</Version>
+		<Version>1.1.0</Version>
 		<RepositoryUrl>https://github.com/kaby76/Trash/tree/main/src/trxml2</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
 	</PropertyGroup>

--- a/src/web/driver/driver.csproj
+++ b/src/web/driver/driver.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.8" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.8" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.9" />
    <PackageReference Include="Antlr4.Runtime.Standard" Version="4.13.1" />
     <PackageReference Include="Domemtech.AutomaticGraphLayout" Version="1.1.4" />
     <PackageReference Include="Domemtech.AutomaticGraphLayout.Drawing" Version="1.1.4" />

--- a/src/web/driver/driver.csproj
+++ b/src/web/driver/driver.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.8" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.9" PrivateAssets="all" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.8" />
    <PackageReference Include="Antlr4.Runtime.Standard" Version="4.13.1" />
     <PackageReference Include="Domemtech.AutomaticGraphLayout" Version="1.1.4" />

--- a/src/web/wrap/wrap.csproj
+++ b/src/web/wrap/wrap.csproj
@@ -10,7 +10,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="10.0.8" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="10.0.9" />
     <PackageReference Include="Microsoft.TypeScript.MSBuild" Version="6.0.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
* Fix Cpp target templates.
* Add tokens per second perf measurement to trgen templates.
* Backed out file encoding open for C# target because of regression in [molecule](https://github.com/antlr/grammars-v4/tree/master/molecule).