### PR TITLE
trsort: rewrite CReorder.cs and update Command.cs/Config.cs

### DIFF
--- a/src/trsort/CReorder.cs
+++ b/src/trsort/CReorder.cs
@@ -1,78 +1,189 @@
-﻿//namespace Trash.Commands
-//{
-//    using Antlr4.Runtime.Tree;
-//    using LanguageServer;
-//    using org.eclipse.wst.xml.xpath2.processor.util;
-//    using System;
-//    using System.Collections.Generic;
-//    using System.Linq;
+namespace Trash;
 
-//    class CReorder
-//    {
-//        public void Help()
-//        {
-//            System.Console.WriteLine(@"reorder alpha
-//reorder bfs <string>
-//reorder dfs <string>
-//Reorder the parser rules according to the specified type and start rule.
-//For BFS and DFS, an XPath expression must be supplied to specify all the start
-//rule symbols. For alphabetic reordering, all parser rules are retained, and
-//simply reordered alphabetically. For BFS and DFS, if the rule is unreachable
-//from a start node set that is specified via <string>, then the rule is dropped
-//from the grammar.
+using org.eclipse.wst.xml.xpath2.processor.util;
+using ParseTreeEditing.UnvParseTreeDOM;
+using System.Collections.Generic;
+using System.Linq;
+using Antlr4.Runtime;
 
-//Example:
-//    reorder alpha
-//    reorder dfs ""//parserRuleSpec/RULE_REF[text()='libraryDefinition']""
-//");
-//        }
+class CReorder
+{
+    static readonly org.eclipse.wst.xml.xpath2.processor.Engine _engine =
+        new org.eclipse.wst.xml.xpath2.processor.Engine();
 
-//        public void Execute(Repl repl, ReplParser.ReorderContext tree, bool piped)
-//        {
-//            Dictionary<string, string> results = new Dictionary<string, string>();
-//            var doc = repl.stack.Peek();
-//            string expr = null;
-//            if (tree.modes() != null)
-//            {
-//                results = LanguageServer.Transform.SortModes(doc);
-//            }
-//            else
-//            {
-//                LspAntlr.ReorderType order = default;
-//                if (tree.alpha() != null)
-//                    order = LspAntlr.ReorderType.Alphabetically;
-//                else if (tree.bfs() != null)
-//                {
-//                    order = LspAntlr.ReorderType.BFS;
-//                    expr = tree.bfs().StringLiteral().GetText();
-//                }
-//                else if (tree.dfs() != null)
-//                {
-//                    order = LspAntlr.ReorderType.DFS;
-//                    expr = tree.dfs().StringLiteral().GetText();
-//                }
-//                else
-//                    throw new Exception("unknown sorting type");
-//                List<IParseTree> nodes = null;
-//                if (expr != null)
-//                {
-//                    expr = expr.Substring(1, expr.Length - 2);
-//                    var pr = ParsingResultsFactory.Create(doc);
-//                    var aparser = pr.Parser;
-//                    var atree = pr.ParseTree;
-//                    using
-//                    (ParseTreeEditing.AntlrDOM.AntlrDynamicContext
-//                    dynamicContext = new ParseTreeEditing.AntlrDOM.ConvertToDOM().Try(atree, aparser))
-//                    {
-//                        org.eclipse.wst.xml.xpath2.processor.Engine engine = new org.eclipse.wst.xml.xpath2.processor.Engine();
-//                        nodes = engine.parseExpression(expr,
-//                                new StaticContextBuilder()).evaluate(dynamicContext, new object[] { dynamicContext.Document })
-//                            .Select(x => (x.NativeValue as ParseTreeEditing.AntlrDOM.AntlrElement).AntlrIParseTree).ToList();
-//                    }
-//                }
-//                results = LanguageServer.Transform.ReorderParserRules(doc, order, nodes);
-//            }
-//            repl.EnactEdits(results);
-//        }
-//    }
-//}
+    // Sort all parser rules alphabetically by rule name, keeping all rules.
+    public static void AlphaSort(UnvParseTreeNode[] trees, Parser parser)
+    {
+        var ate = new ConvertToDOM();
+        using var dynamicContext = ate.Try(trees, parser);
+
+        var ruleNodes = _engine.parseExpression("//ruleSpec[parserRuleSpec]",
+                new StaticContextBuilder())
+            .evaluate(dynamicContext, new object[] { dynamicContext.Document })
+            .Select(x => x.NativeValue as UnvParseTreeElement)
+            .ToList();
+
+        if (ruleNodes.Count == 0) return;
+
+        var list = new List<(string name, UnvParseTreeNode node)>();
+        foreach (var node in ruleNodes)
+        {
+            var name = _engine.parseExpression("./parserRuleSpec/RULE_REF/text()",
+                    new StaticContextBuilder())
+                .evaluate(dynamicContext, new object[] { node })
+                .Select(x => x.NativeValue as UnvParseTreeText)
+                .First().NodeValue as string;
+            list.Add((name, node));
+        }
+
+        // Sort descending so that inserting each at position 0 yields ascending order.
+        list.Sort((x, y) => string.Compare(y.name, x.name, System.StringComparison.Ordinal));
+
+        var rulesContainer = list[0].node.ParentNode as UnvParseTreeNode;
+        foreach (var (_, node) in list)
+            TreeEdits.MoveToFirstChild(node, rulesContainer);
+    }
+
+    // Sort reachable parser rules in BFS order starting from rules matched by startExpr.
+    // Rules unreachable from the start set are dropped from the grammar.
+    public static void BfsSort(UnvParseTreeNode[] trees, Parser parser, string startExpr)
+        => ReachabilitySort(trees, parser, startExpr, bfs: true);
+
+    // Sort reachable parser rules in DFS preorder starting from rules matched by startExpr.
+    // Rules unreachable from the start set are dropped from the grammar.
+    public static void DfsSort(UnvParseTreeNode[] trees, Parser parser, string startExpr)
+        => ReachabilitySort(trees, parser, startExpr, bfs: false);
+
+    static void ReachabilitySort(UnvParseTreeNode[] trees, Parser parser, string startExpr, bool bfs)
+    {
+        var ate = new ConvertToDOM();
+        using var dynamicContext = ate.Try(trees, parser);
+
+        // Build map: rule name -> ruleSpec node.
+        var ruleNodes = _engine.parseExpression("//ruleSpec[parserRuleSpec]",
+                new StaticContextBuilder())
+            .evaluate(dynamicContext, new object[] { dynamicContext.Document })
+            .Select(x => x.NativeValue as UnvParseTreeElement)
+            .ToList();
+
+        if (ruleNodes.Count == 0) return;
+
+        var nameToNode = new Dictionary<string, UnvParseTreeNode>();
+        foreach (var node in ruleNodes)
+        {
+            var name = _engine.parseExpression("./parserRuleSpec/RULE_REF/text()",
+                    new StaticContextBuilder())
+                .evaluate(dynamicContext, new object[] { node })
+                .Select(x => x.NativeValue as UnvParseTreeText)
+                .First().NodeValue as string;
+            nameToNode[name] = node;
+        }
+
+        // Build adjacency: rule name -> list of parser rule names referenced in body.
+        var adjacency = new Dictionary<string, List<string>>();
+        foreach (var kvp in nameToNode)
+        {
+            var refs = _engine.parseExpression("./parserRuleSpec/ruleBlock//RULE_REF/text()",
+                    new StaticContextBuilder())
+                .evaluate(dynamicContext, new object[] { kvp.Value })
+                .Select(x => x.NativeValue as UnvParseTreeText)
+                .Select(t => t.NodeValue as string)
+                .Where(n => nameToNode.ContainsKey(n))
+                .Distinct()
+                .ToList();
+            adjacency[kvp.Key] = refs;
+        }
+
+        // Evaluate the user-supplied XPath to find start rules.
+        var startItems = _engine.parseExpression(startExpr,
+                new StaticContextBuilder())
+            .evaluate(dynamicContext, new object[] { dynamicContext.Document })
+            .ToList();
+
+        var startNames = new List<string>();
+        foreach (var item in startItems)
+        {
+            string name = null;
+            var native = item.NativeValue;
+            if (native is UnvParseTreeText txt)
+                name = txt.NodeValue as string;
+            else if (native is UnvParseTreeElement elem)
+                name = elem.GetChildrenText().FirstOrDefault();
+            if (name != null && nameToNode.ContainsKey(name))
+                startNames.Add(name);
+        }
+
+        if (startNames.Count == 0) return;
+
+        // Traverse graph to get ordered reachable rule names.
+        var ordered = bfs ? BfsOrder(startNames, adjacency) : DfsOrder(startNames, adjacency);
+        if (ordered.Count == 0) return;
+
+        // Capture the rules container before any deletions.
+        var rulesContainer = ruleNodes[0].ParentNode as UnvParseTreeNode;
+
+        // Drop rules that are unreachable from the start set.
+        var reachable = new HashSet<string>(ordered);
+        foreach (var kvp in nameToNode.ToList())
+        {
+            if (!reachable.Contains(kvp.Key))
+                TreeEdits.Delete(kvp.Value);
+        }
+
+        // Reorder remaining rules: insert in reverse order so position-0 insertions
+        // produce the desired final order.
+        for (int i = ordered.Count - 1; i >= 0; i--)
+            TreeEdits.MoveToFirstChild(nameToNode[ordered[i]], rulesContainer);
+    }
+
+    static List<string> BfsOrder(List<string> startNames, Dictionary<string, List<string>> adjacency)
+    {
+        var visited = new HashSet<string>();
+        var queue = new Queue<string>();
+        var result = new List<string>();
+
+        foreach (var name in startNames)
+        {
+            if (adjacency.ContainsKey(name) && visited.Add(name))
+                queue.Enqueue(name);
+        }
+
+        while (queue.Count > 0)
+        {
+            var current = queue.Dequeue();
+            result.Add(current);
+            if (adjacency.TryGetValue(current, out var refs))
+            {
+                foreach (var next in refs)
+                {
+                    if (visited.Add(next))
+                        queue.Enqueue(next);
+                }
+            }
+        }
+
+        return result;
+    }
+
+    static List<string> DfsOrder(List<string> startNames, Dictionary<string, List<string>> adjacency)
+    {
+        var visited = new HashSet<string>();
+        var result = new List<string>();
+
+        void Dfs(string name)
+        {
+            if (!visited.Add(name)) return;
+            result.Add(name);
+            if (adjacency.TryGetValue(name, out var refs))
+            {
+                foreach (var next in refs)
+                    Dfs(next);
+            }
+        }
+
+        foreach (var name in startNames)
+            Dfs(name);
+
+        return result;
+    }
+}

--- a/src/trsort/CReorder.cs
+++ b/src/trsort/CReorder.cs
@@ -106,9 +106,27 @@ class CReorder
             string name = null;
             var native = item.NativeValue;
             if (native is UnvParseTreeText txt)
+            {
                 name = txt.NodeValue as string;
+            }
             else if (native is UnvParseTreeElement elem)
-                name = elem.GetChildrenText().FirstOrDefault();
+            {
+                if (elem.LocalName == "RULE_REF")
+                {
+                    // XPath selected the RULE_REF token element itself.
+                    name = elem.GetChildrenText().FirstOrDefault();
+                }
+                else
+                {
+                    // For parserRuleSpec, ruleSpec, or any other container: the first
+                    // descendant RULE_REF in document order is the rule name.
+                    name = _engine.parseExpression(".//RULE_REF/text()",
+                            new StaticContextBuilder())
+                        .evaluate(dynamicContext, new object[] { elem })
+                        .Select(x => x.NativeValue as UnvParseTreeText)
+                        .FirstOrDefault()?.NodeValue as string;
+                }
+            }
             if (name != null && nameToNode.ContainsKey(name))
                 startNames.Add(name);
         }

--- a/src/trsort/CReorder.cs
+++ b/src/trsort/CReorder.cs
@@ -44,17 +44,19 @@ class CReorder
             TreeEdits.MoveToFirstChild(node, rulesContainer);
     }
 
-    // Sort reachable parser rules in BFS order starting from rules matched by startExpr.
-    // Rules unreachable from the start set are dropped from the grammar.
-    public static void BfsSort(UnvParseTreeNode[] trees, Parser parser, string startExpr)
-        => ReachabilitySort(trees, parser, startExpr, bfs: true);
+    // Sort reachable parser rules in BFS order starting from the named start rule.
+    // Pass null to auto-detect the start rule via the EOF-alternative heuristic.
+    // Rules unreachable from the start rule are dropped from the grammar.
+    public static void BfsSort(UnvParseTreeNode[] trees, Parser parser, string startRule)
+        => ReachabilitySort(trees, parser, startRule, bfs: true);
 
-    // Sort reachable parser rules in DFS preorder starting from rules matched by startExpr.
-    // Rules unreachable from the start set are dropped from the grammar.
-    public static void DfsSort(UnvParseTreeNode[] trees, Parser parser, string startExpr)
-        => ReachabilitySort(trees, parser, startExpr, bfs: false);
+    // Sort reachable parser rules in DFS preorder starting from the named start rule.
+    // Pass null to auto-detect the start rule via the EOF-alternative heuristic.
+    // Rules unreachable from the start rule are dropped from the grammar.
+    public static void DfsSort(UnvParseTreeNode[] trees, Parser parser, string startRule)
+        => ReachabilitySort(trees, parser, startRule, bfs: false);
 
-    static void ReachabilitySort(UnvParseTreeNode[] trees, Parser parser, string startExpr, bool bfs)
+    static void ReachabilitySort(UnvParseTreeNode[] trees, Parser parser, string startRule, bool bfs)
     {
         var ate = new ConvertToDOM();
         using var dynamicContext = ate.Try(trees, parser);
@@ -96,7 +98,7 @@ class CReorder
 
         // Resolve the set of start rule names.
         List<string> startNames;
-        if (string.IsNullOrEmpty(startExpr))
+        if (string.IsNullOrEmpty(startRule))
         {
             // Auto-detect: find parser rule(s) in non-lexer grammars whose alternatives
             // contain an EOF token.  The first descendant RULE_REF of each matched
@@ -144,41 +146,14 @@ class CReorder
         }
         else
         {
-            // Evaluate the user-supplied XPath expression.
-            var startItems = _engine.parseExpression(startExpr, new StaticContextBuilder())
-                .evaluate(dynamicContext, new object[] { dynamicContext.Document })
-                .ToList();
-
-            startNames = new List<string>();
-            foreach (var item in startItems)
+            // The caller supplied a rule name directly.  Look it up in the grammar.
+            if (!nameToNode.ContainsKey(startRule))
             {
-                string name = null;
-                var native = item.NativeValue;
-                if (native is UnvParseTreeText txt)
-                {
-                    name = txt.NodeValue as string;
-                }
-                else if (native is UnvParseTreeElement elem)
-                {
-                    if (elem.LocalName == "RULE_REF")
-                    {
-                        // XPath selected the RULE_REF token element itself.
-                        name = elem.GetChildrenText().FirstOrDefault();
-                    }
-                    else
-                    {
-                        // For parserRuleSpec, ruleSpec, or any other container: the first
-                        // descendant RULE_REF in document order is the rule name.
-                        name = _engine.parseExpression(".//RULE_REF/text()",
-                                new StaticContextBuilder())
-                            .evaluate(dynamicContext, new object[] { elem })
-                            .Select(x => x.NativeValue as UnvParseTreeText)
-                            .FirstOrDefault()?.NodeValue as string;
-                    }
-                }
-                if (name != null && nameToNode.ContainsKey(name))
-                    startNames.Add(name);
+                System.Console.Error.WriteLine(
+                    $"trsort: start rule '{startRule}' not found in grammar.");
+                throw new System.Exception($"Start rule '{startRule}' not found.");
             }
+            startNames = new List<string> { startRule };
         }
 
         if (startNames.Count == 0) return;

--- a/src/trsort/CReorder.cs
+++ b/src/trsort/CReorder.cs
@@ -103,9 +103,7 @@ class CReorder
             // Auto-detect: find parser rule(s) in non-lexer grammars whose alternatives
             // contain an EOF token.  The first descendant RULE_REF of each matched
             // parserRuleSpec is its rule name.
-            const string autoXPath =
-                "//grammarSpec/grammarDecl[not(grammarType/LEXER)]" +
-                "//parserRuleSpec[.//alternative/element[.//TOKEN_REF/text()=\"EOF\"]]";
+	    const string autoXPath = "//parserRuleSpec[./ruleBlock//TOKEN_REF/text()='EOF']";
 
             var detected = _engine.parseExpression(autoXPath, new StaticContextBuilder())
                 .evaluate(dynamicContext, new object[] { dynamicContext.Document })

--- a/src/trsort/CReorder.cs
+++ b/src/trsort/CReorder.cs
@@ -94,41 +94,91 @@ class CReorder
             adjacency[kvp.Key] = refs;
         }
 
-        // Evaluate the user-supplied XPath to find start rules.
-        var startItems = _engine.parseExpression(startExpr,
-                new StaticContextBuilder())
-            .evaluate(dynamicContext, new object[] { dynamicContext.Document })
-            .ToList();
-
-        var startNames = new List<string>();
-        foreach (var item in startItems)
+        // Resolve the set of start rule names.
+        List<string> startNames;
+        if (string.IsNullOrEmpty(startExpr))
         {
-            string name = null;
-            var native = item.NativeValue;
-            if (native is UnvParseTreeText txt)
+            // Auto-detect: find parser rule(s) in non-lexer grammars whose alternatives
+            // contain an EOF token.  The first descendant RULE_REF of each matched
+            // parserRuleSpec is its rule name.
+            const string autoXPath =
+                "//grammarSpec/grammarDecl[not(grammarType/LEXER)]" +
+                "//parserRuleSpec[.//alternative/element[.//TOKEN_REF/text()=\"EOF\"]]";
+
+            var detected = _engine.parseExpression(autoXPath, new StaticContextBuilder())
+                .evaluate(dynamicContext, new object[] { dynamicContext.Document })
+                .Select(x => x.NativeValue as UnvParseTreeElement)
+                .ToList();
+
+            if (detected.Count == 0)
             {
-                name = txt.NodeValue as string;
+                System.Console.Error.WriteLine(
+                    "trsort: cannot auto-detect start rule: " +
+                    "no parser rule with an EOF alternative found. " +
+                    "Provide an XPath expression explicitly.");
+                throw new System.Exception("Auto-detect: no start rule found.");
             }
-            else if (native is UnvParseTreeElement elem)
+            if (detected.Count > 1)
             {
-                if (elem.LocalName == "RULE_REF")
+                System.Console.Error.WriteLine(
+                    "trsort: cannot auto-detect start rule: " +
+                    "multiple parser rules contain an EOF alternative:");
+                foreach (var d in detected)
                 {
-                    // XPath selected the RULE_REF token element itself.
-                    name = elem.GetChildrenText().FirstOrDefault();
-                }
-                else
-                {
-                    // For parserRuleSpec, ruleSpec, or any other container: the first
-                    // descendant RULE_REF in document order is the rule name.
-                    name = _engine.parseExpression(".//RULE_REF/text()",
-                            new StaticContextBuilder())
-                        .evaluate(dynamicContext, new object[] { elem })
+                    var n = _engine.parseExpression("./RULE_REF/text()", new StaticContextBuilder())
+                        .evaluate(dynamicContext, new object[] { d })
                         .Select(x => x.NativeValue as UnvParseTreeText)
                         .FirstOrDefault()?.NodeValue as string;
+                    System.Console.Error.WriteLine("  " + n);
                 }
+                System.Console.Error.WriteLine(
+                    "Provide an XPath expression explicitly to choose a start rule.");
+                throw new System.Exception("Auto-detect: multiple start rules found.");
             }
-            if (name != null && nameToNode.ContainsKey(name))
-                startNames.Add(name);
+
+            var detectedName = _engine.parseExpression("./RULE_REF/text()", new StaticContextBuilder())
+                .evaluate(dynamicContext, new object[] { detected[0] })
+                .Select(x => x.NativeValue as UnvParseTreeText)
+                .First().NodeValue as string;
+            startNames = new List<string> { detectedName };
+        }
+        else
+        {
+            // Evaluate the user-supplied XPath expression.
+            var startItems = _engine.parseExpression(startExpr, new StaticContextBuilder())
+                .evaluate(dynamicContext, new object[] { dynamicContext.Document })
+                .ToList();
+
+            startNames = new List<string>();
+            foreach (var item in startItems)
+            {
+                string name = null;
+                var native = item.NativeValue;
+                if (native is UnvParseTreeText txt)
+                {
+                    name = txt.NodeValue as string;
+                }
+                else if (native is UnvParseTreeElement elem)
+                {
+                    if (elem.LocalName == "RULE_REF")
+                    {
+                        // XPath selected the RULE_REF token element itself.
+                        name = elem.GetChildrenText().FirstOrDefault();
+                    }
+                    else
+                    {
+                        // For parserRuleSpec, ruleSpec, or any other container: the first
+                        // descendant RULE_REF in document order is the rule name.
+                        name = _engine.parseExpression(".//RULE_REF/text()",
+                                new StaticContextBuilder())
+                            .evaluate(dynamicContext, new object[] { elem })
+                            .Select(x => x.NativeValue as UnvParseTreeText)
+                            .FirstOrDefault()?.NodeValue as string;
+                    }
+                }
+                if (name != null && nameToNode.ContainsKey(name))
+                    startNames.Add(name);
+            }
         }
 
         if (startNames.Count == 0) return;

--- a/src/trsort/CReorder.cs
+++ b/src/trsort/CReorder.cs
@@ -1,39 +1,34 @@
 namespace Trash;
 
-using org.eclipse.wst.xml.xpath2.processor.util;
 using ParseTreeEditing.UnvParseTreeDOM;
 using System.Collections.Generic;
 using System.Linq;
 using Antlr4.Runtime;
+using XQuery.Engine;
+using XPathParser = XQuery.Parser.XPathParser;
 
 class CReorder
 {
-    static readonly org.eclipse.wst.xml.xpath2.processor.Engine _engine =
-        new org.eclipse.wst.xml.xpath2.processor.Engine();
+    static readonly XPathEvaluator _evaluator = new XPathEvaluator();
 
     // Sort all parser rules alphabetically by rule name, keeping all rules.
     public static void AlphaSort(UnvParseTreeNode[] trees, Parser parser)
     {
-        var ate = new ConvertToDOM();
-        using var dynamicContext = ate.Try(trees, parser);
+        var adapterDoc = AdapterDocument.Build(trees);
 
-        var ruleNodes = _engine.parseExpression("//ruleSpec[parserRuleSpec]",
-                new StaticContextBuilder())
-            .evaluate(dynamicContext, new object[] { dynamicContext.Document })
-            .Select(x => x.NativeValue as UnvParseTreeElement)
-            .ToList();
+        var ruleSpecExpr = new XPathParser("//ruleSpec[parserRuleSpec]").Parse();
+        var ruleAdapters = _evaluator.Evaluate(ruleSpecExpr, adapterDoc)
+            .OfType<AdapterElement>().ToList();
 
-        if (ruleNodes.Count == 0) return;
+        if (ruleAdapters.Count == 0) return;
 
+        var nameExpr = new XPathParser("./parserRuleSpec/RULE_REF/text()").Parse();
         var list = new List<(string name, UnvParseTreeNode node)>();
-        foreach (var node in ruleNodes)
+        foreach (var ruleAdapter in ruleAdapters)
         {
-            var name = _engine.parseExpression("./parserRuleSpec/RULE_REF/text()",
-                    new StaticContextBuilder())
-                .evaluate(dynamicContext, new object[] { node })
-                .Select(x => x.NativeValue as UnvParseTreeText)
-                .First().NodeValue as string;
-            list.Add((name, node));
+            var name = _evaluator.Evaluate(nameExpr, ruleAdapter)
+                .OfType<AdapterText>().First().Source.Data;
+            list.Add((name, ruleAdapter.Source));
         }
 
         // Sort descending so that inserting each at position 0 yields ascending order.
@@ -48,48 +43,44 @@ class CReorder
     // Pass null to auto-detect the start rule via the EOF-alternative heuristic.
     // Rules unreachable from the start rule are dropped from the grammar.
     public static void BfsSort(UnvParseTreeNode[] trees, Parser parser, string startRule)
-        => ReachabilitySort(trees, parser, startRule, bfs: true);
+        => ReachabilitySort(trees, startRule, bfs: true);
 
     // Sort reachable parser rules in DFS preorder starting from the named start rule.
     // Pass null to auto-detect the start rule via the EOF-alternative heuristic.
     // Rules unreachable from the start rule are dropped from the grammar.
     public static void DfsSort(UnvParseTreeNode[] trees, Parser parser, string startRule)
-        => ReachabilitySort(trees, parser, startRule, bfs: false);
+        => ReachabilitySort(trees, startRule, bfs: false);
 
-    static void ReachabilitySort(UnvParseTreeNode[] trees, Parser parser, string startRule, bool bfs)
+    static void ReachabilitySort(UnvParseTreeNode[] trees, string startRule, bool bfs)
     {
-        var ate = new ConvertToDOM();
-        using var dynamicContext = ate.Try(trees, parser);
+        var adapterDoc = AdapterDocument.Build(trees);
 
-        // Build map: rule name -> ruleSpec node.
-        var ruleNodes = _engine.parseExpression("//ruleSpec[parserRuleSpec]",
-                new StaticContextBuilder())
-            .evaluate(dynamicContext, new object[] { dynamicContext.Document })
-            .Select(x => x.NativeValue as UnvParseTreeElement)
-            .ToList();
+        // Build map: rule name -> ruleSpec node and AdapterElement.
+        var ruleSpecExpr = new XPathParser("//ruleSpec[parserRuleSpec]").Parse();
+        var ruleAdapters = _evaluator.Evaluate(ruleSpecExpr, adapterDoc)
+            .OfType<AdapterElement>().ToList();
 
-        if (ruleNodes.Count == 0) return;
+        if (ruleAdapters.Count == 0) return;
 
+        var nameExpr = new XPathParser("./parserRuleSpec/RULE_REF/text()").Parse();
         var nameToNode = new Dictionary<string, UnvParseTreeNode>();
-        foreach (var node in ruleNodes)
+        var nameToAdapter = new Dictionary<string, AdapterElement>();
+        foreach (var ruleAdapter in ruleAdapters)
         {
-            var name = _engine.parseExpression("./parserRuleSpec/RULE_REF/text()",
-                    new StaticContextBuilder())
-                .evaluate(dynamicContext, new object[] { node })
-                .Select(x => x.NativeValue as UnvParseTreeText)
-                .First().NodeValue as string;
-            nameToNode[name] = node;
+            var name = _evaluator.Evaluate(nameExpr, ruleAdapter)
+                .OfType<AdapterText>().First().Source.Data;
+            nameToNode[name] = ruleAdapter.Source;
+            nameToAdapter[name] = ruleAdapter;
         }
 
         // Build adjacency: rule name -> list of parser rule names referenced in body.
+        var refsExpr = new XPathParser("./parserRuleSpec/ruleBlock//RULE_REF/text()").Parse();
         var adjacency = new Dictionary<string, List<string>>();
-        foreach (var kvp in nameToNode)
+        foreach (var kvp in nameToAdapter)
         {
-            var refs = _engine.parseExpression("./parserRuleSpec/ruleBlock//RULE_REF/text()",
-                    new StaticContextBuilder())
-                .evaluate(dynamicContext, new object[] { kvp.Value })
-                .Select(x => x.NativeValue as UnvParseTreeText)
-                .Select(t => t.NodeValue as string)
+            var refs = _evaluator.Evaluate(refsExpr, kvp.Value)
+                .OfType<AdapterText>()
+                .Select(t => t.Source.Data)
                 .Where(n => nameToNode.ContainsKey(n))
                 .Distinct()
                 .ToList();
@@ -100,24 +91,22 @@ class CReorder
         List<string> startNames;
         if (string.IsNullOrEmpty(startRule))
         {
-            // Auto-detect: find parser rule(s) in non-lexer grammars whose alternatives
-            // contain an EOF token.  The first descendant RULE_REF of each matched
-            // parserRuleSpec is its rule name.
-	    const string autoXPath = "//parserRuleSpec[./ruleBlock//TOKEN_REF/text()='EOF']";
-
-            var detected = _engine.parseExpression(autoXPath, new StaticContextBuilder())
-                .evaluate(dynamicContext, new object[] { dynamicContext.Document })
-                .Select(x => x.NativeValue as UnvParseTreeElement)
-                .ToList();
+            // Auto-detect: find parser rule(s) whose rule body contains an EOF token.
+            const string autoXPath = "//parserRuleSpec[./ruleBlock//TOKEN_REF/text()='EOF']";
+            var autoExpr = new XPathParser(autoXPath).Parse();
+            var detected = _evaluator.Evaluate(autoExpr, adapterDoc)
+                .OfType<AdapterElement>().ToList();
 
             if (detected.Count == 0)
             {
                 System.Console.Error.WriteLine(
                     "trsort: cannot auto-detect start rule: " +
                     "no parser rule with an EOF alternative found. " +
-                    "Provide an XPath expression explicitly.");
+                    "Provide a start rule name explicitly.");
                 throw new System.Exception("Auto-detect: no start rule found.");
             }
+
+            var ruleRefExpr = new XPathParser("./RULE_REF/text()").Parse();
             if (detected.Count > 1)
             {
                 System.Console.Error.WriteLine(
@@ -125,26 +114,22 @@ class CReorder
                     "multiple parser rules contain an EOF alternative:");
                 foreach (var d in detected)
                 {
-                    var n = _engine.parseExpression("./RULE_REF/text()", new StaticContextBuilder())
-                        .evaluate(dynamicContext, new object[] { d })
-                        .Select(x => x.NativeValue as UnvParseTreeText)
-                        .FirstOrDefault()?.NodeValue as string;
+                    var n = _evaluator.Evaluate(ruleRefExpr, d)
+                        .OfType<AdapterText>().FirstOrDefault()?.Source.Data;
                     System.Console.Error.WriteLine("  " + n);
                 }
                 System.Console.Error.WriteLine(
-                    "Provide an XPath expression explicitly to choose a start rule.");
+                    "Provide a start rule name explicitly.");
                 throw new System.Exception("Auto-detect: multiple start rules found.");
             }
 
-            var detectedName = _engine.parseExpression("./RULE_REF/text()", new StaticContextBuilder())
-                .evaluate(dynamicContext, new object[] { detected[0] })
-                .Select(x => x.NativeValue as UnvParseTreeText)
-                .First().NodeValue as string;
+            var detectedName = _evaluator.Evaluate(ruleRefExpr, detected[0])
+                .OfType<AdapterText>().First().Source.Data;
             startNames = new List<string> { detectedName };
         }
         else
         {
-            // The caller supplied a rule name directly.  Look it up in the grammar.
+            // The caller supplied a rule name directly. Look it up in the grammar.
             if (!nameToNode.ContainsKey(startRule))
             {
                 System.Console.Error.WriteLine(
@@ -161,7 +146,7 @@ class CReorder
         if (ordered.Count == 0) return;
 
         // Capture the rules container before any deletions.
-        var rulesContainer = ruleNodes[0].ParentNode as UnvParseTreeNode;
+        var rulesContainer = ruleAdapters[0].Source.ParentNode as UnvParseTreeNode;
 
         // Drop rules that are unreachable from the start set.
         var reachable = new HashSet<string>(ordered);

--- a/src/trsort/Command.cs
+++ b/src/trsort/Command.cs
@@ -1,13 +1,9 @@
-﻿using AntlrJson;
-using org.eclipse.wst.xml.xpath2.processor.@internal.ast;
-using org.eclipse.wst.xml.xpath2.processor.util;
+using AntlrJson;
 using ParseTreeEditing.UnvParseTreeDOM;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text;
 using System.Text.Json;
-using Antlr4.Runtime.Misc;
 
 namespace Trash;
 
@@ -24,20 +20,11 @@ class Command
 
     public void Execute(Config config)
     {
-        var expr = "//ruleSpec[parserRuleSpec]";
-        if (config.Verbose)
-        {
-            //System.Console.Error.WriteLine("from = >>>" + from + "<<<");
-            //System.Console.Error.WriteLine("to = >>>" + to + "<<<");
-        }
-
         string lines = null;
         if (!(config.File != null && config.File != ""))
         {
             if (config.Verbose)
-            {
                 System.Console.Error.WriteLine("reading from stdin");
-            }
 
             for (;;)
             {
@@ -48,9 +35,7 @@ class Command
         else
         {
             if (config.Verbose)
-            {
                 System.Console.Error.WriteLine("reading from file >>>" + config.File + "<<<");
-            }
 
             lines = File.ReadAllText(config.File);
         }
@@ -61,75 +46,46 @@ class Command
         serializeOptions.MaxDepth = 10000;
         var data = JsonSerializer.Deserialize<AntlrJson.ParsingResultSet[]>(lines, serializeOptions);
         var results = new List<ParsingResultSet>();
+
         foreach (var parse_info in data)
         {
             var fn = parse_info.FileName;
             var trees = parse_info.Nodes;
             var parser = parse_info.Parser;
             var lexer = parse_info.Lexer;
+
             if (config.Verbose)
             {
                 foreach (var n in trees)
                     System.Console.WriteLine(new TreeOutput(lexer, parser).OutputTree(n).ToString());
             }
 
-            org.eclipse.wst.xml.xpath2.processor.Engine engine = new org.eclipse.wst.xml.xpath2.processor.Engine();
-            var ate = new ParseTreeEditing.UnvParseTreeDOM.ConvertToDOM();
-            using (AntlrDynamicContext dynamicContext = ate.Try(trees, parser))
+            if (config.Bfs)
             {
-                var nodes = engine.parseExpression(expr,
-                        new StaticContextBuilder()).evaluate(dynamicContext, new object[] { dynamicContext.Document })
-                    .Select(x => (x.NativeValue as ParseTreeEditing.UnvParseTreeDOM.UnvParseTreeElement)).ToList();
-                if (config.Verbose) LoggerNs.TimedStderrOutput.WriteLine("Found " + nodes.Count + " nodes.");
-                var list = new List<Pair<string, ParseTreeEditing.UnvParseTreeDOM.UnvParseTreeNode>>();
-                foreach (UnvParseTreeElement node in nodes)
-                {
-                    // Get name.
-                    var name = engine.parseExpression("./parserRuleSpec/RULE_REF/text()",
-                            new StaticContextBuilder()).evaluate(dynamicContext,
-                            new object[] { node }) 
-                        .Select(x => (x.NativeValue as ParseTreeEditing.UnvParseTreeDOM.UnvParseTreeText))
-                        .ToList().First().NodeValue as string;
-                    // Add to list of {name x node} pairs to be sorted.
-                    list.Add(new Pair<string, ParseTreeEditing.UnvParseTreeDOM.UnvParseTreeNode>(name, node));
-               //     if (config.Verbose) LoggerNs.TimedStderrOutput.WriteLine("Found " + defs.Count + " defs.");
-                }
-                // reverse sort list by name.
-                list.Sort((x, y) => y.a.CompareTo(x.a));
-
-                if (config.Verbose)
-                {
-                    System.Console.Error.WriteLine("list:");
-                    foreach (var p in list)
-                    {
-                        System.Console.Error.WriteLine(p.a);
-                    }
-                }
-                // Fix up grammar.
-                if (list.Count > 0)
-                {
-                    // Find first rule in grammar.
-                    var to = engine.parseExpression("//ruleSpec[parserRuleSpec][1]",
-                            new StaticContextBuilder()).evaluate(dynamicContext,
-                            new object[] { dynamicContext.Document })
-                        .Select(x => (x.NativeValue as ParseTreeEditing.UnvParseTreeDOM.UnvParseTreeNode))
-                        .First();
-                    foreach (var p in list)
-                    {
-                        TreeEdits.MoveToFirstChild(p.b, to.ParentNode as ParseTreeEditing.UnvParseTreeDOM.UnvParseTreeNode);
-                        to = p.b;
-                    }
-                }
-
-                var tuple = new ParsingResultSet()
-                {
-                    FileName = fn,
-                    Nodes = trees,
-                    Lexer = lexer,
-                    Parser = parser
-                };
-                results.Add(tuple);
+                if (string.IsNullOrEmpty(config.Expr))
+                    throw new System.Exception("--bfs requires an XPath expression argument identifying start rules.");
+                CReorder.BfsSort(trees, parser, config.Expr);
             }
+            else if (config.Dfs)
+            {
+                if (string.IsNullOrEmpty(config.Expr))
+                    throw new System.Exception("--dfs requires an XPath expression argument identifying start rules.");
+                CReorder.DfsSort(trees, parser, config.Expr);
+            }
+            else
+            {
+                // Default: alphabetic sort.
+                CReorder.AlphaSort(trees, parser);
+            }
+
+            var tuple = new ParsingResultSet()
+            {
+                FileName = fn,
+                Nodes = trees,
+                Lexer = lexer,
+                Parser = parser
+            };
+            results.Add(tuple);
         }
 
         if (config.Verbose) LoggerNs.TimedStderrOutput.WriteLine("starting serialization");

--- a/src/trsort/Command.cs
+++ b/src/trsort/Command.cs
@@ -67,14 +67,12 @@ class Command
 
             if (config.Bfs)
             {
-                if (string.IsNullOrEmpty(config.Expr))
-                    throw new System.Exception("--bfs requires an XPath expression argument identifying start rules.");
+                // startExpr may be null; CReorder will auto-detect the start rule in that case.
                 CReorder.BfsSort(trees, parser, config.Expr);
             }
             else if (config.Dfs)
             {
-                if (string.IsNullOrEmpty(config.Expr))
-                    throw new System.Exception("--dfs requires an XPath expression argument identifying start rules.");
+                // startExpr may be null; CReorder will auto-detect the start rule in that case.
                 CReorder.DfsSort(trees, parser, config.Expr);
             }
             else

--- a/src/trsort/Command.cs
+++ b/src/trsort/Command.cs
@@ -40,6 +40,11 @@ class Command
             lines = File.ReadAllText(config.File);
         }
 
+        int modeCount = (config.Alphabetic ? 1 : 0) + (config.Bfs ? 1 : 0) + (config.Dfs ? 1 : 0);
+        if (modeCount > 1)
+            throw new System.Exception(
+                "Conflicting sort options: specify at most one of --alphabetic, --bfs, --dfs.");
+
         var serializeOptions = new JsonSerializerOptions();
         serializeOptions.Converters.Add(new AntlrJson.ParsingResultSetSerializer());
         serializeOptions.WriteIndented = config.Format;

--- a/src/trsort/Command.cs
+++ b/src/trsort/Command.cs
@@ -67,12 +67,12 @@ class Command
 
             if (config.Bfs)
             {
-                // startExpr may be null; CReorder will auto-detect the start rule in that case.
+                // config.Expr is the start rule name, or null to auto-detect.
                 CReorder.BfsSort(trees, parser, config.Expr);
             }
             else if (config.Dfs)
             {
-                // startExpr may be null; CReorder will auto-detect the start rule in that case.
+                // config.Expr is the start rule name, or null to auto-detect.
                 CReorder.DfsSort(trees, parser, config.Expr);
             }
             else

--- a/src/trsort/Config.cs
+++ b/src/trsort/Config.cs
@@ -13,10 +13,10 @@ namespace Trash
         [Option('a', "alphabetic", Required = false, Default = false, HelpText = "Sort parser rules alphabetically (default when no other sort specified).")]
         public bool Alphabetic { get; set; }
 
-        [Option("bfs", Required = false, Default = false, HelpText = "Sort parser rules in BFS order from start rules given by XPath expression.")]
+        [Option("bfs", Required = false, Default = false, HelpText = "Sort parser rules in BFS order from the named start rule.")]
         public bool Bfs { get; set; }
 
-        [Option("dfs", Required = false, Default = false, HelpText = "Sort parser rules in DFS order from start rules given by XPath expression.")]
+        [Option("dfs", Required = false, Default = false, HelpText = "Sort parser rules in DFS order from the named start rule.")]
         public bool Dfs { get; set; }
 
         [Option('v', "verbose", Required = false)]
@@ -25,7 +25,7 @@ namespace Trash
         [Option("version", Required = false)]
         public string Version { get; set; } = "2.0";
 
-        [Value(0, Required = false, HelpText = "XPath expression identifying start rules (required for --bfs and --dfs).")]
+        [Value(0, Required = false, HelpText = "Name of the start rule (optional for --bfs and --dfs; auto-detected when omitted).")]
         public string Expr { get; set; }
     }
 }

--- a/src/trsort/Config.cs
+++ b/src/trsort/Config.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using CommandLine;
 
 namespace Trash
@@ -11,25 +10,22 @@ namespace Trash
         [Option("fmt", Required = false, HelpText = "Output formatted parsing results set.")]
         public bool Format { get; set; }
 
-        [Option('a', "alphabetic", Required = false, Default = true)]
+        [Option('a', "alphabetic", Required = false, Default = false, HelpText = "Sort parser rules alphabetically (default when no other sort specified).")]
         public bool Alphabetic { get; set; }
 
-        [Option('b', "bottom", Required = false, Default = false)]
-        public bool Bottom { get; set; }
-
-        [Option('t', "top", Required = false, Default = false)]
-        public bool Top { get; set; }
-
-        [Option("bfs", Required = false, Default = false)]
+        [Option("bfs", Required = false, Default = false, HelpText = "Sort parser rules in BFS order from start rules given by XPath expression.")]
         public bool Bfs { get; set; }
 
-        [Option("dfs", Required = false, Default = false)]
+        [Option("dfs", Required = false, Default = false, HelpText = "Sort parser rules in DFS order from start rules given by XPath expression.")]
         public bool Dfs { get; set; }
 
         [Option('v', "verbose", Required = false)]
         public bool Verbose { get; set; }
 
-	[Option("version", Required = false)]
-	public string Version { get; set; } = "2.0";
+        [Option("version", Required = false)]
+        public string Version { get; set; } = "2.0";
+
+        [Value(0, Required = false, HelpText = "XPath expression identifying start rules (required for --bfs and --dfs).")]
+        public string Expr { get; set; }
     }
 }

--- a/src/trsort/UnvToXdmAdapter.cs
+++ b/src/trsort/UnvToXdmAdapter.cs
@@ -1,0 +1,138 @@
+using System.Collections.Generic;
+using System.Linq;
+using org.w3c.dom;
+using ParseTreeEditing.UnvParseTreeDOM;
+using XQuery.DataModel;
+
+namespace Trash;
+
+/// <summary>
+/// Wraps a set of UnvParseTreeNode roots as an XdmDocument so the xquery4
+/// engine can navigate the parse tree using standard XPath axes.
+/// </summary>
+sealed class AdapterDocument : XdmDocument
+{
+    private readonly List<XdmNode> _kids = new();
+
+    public override IReadOnlyList<XdmNode> Children => _kids;
+
+    public override string StringValue
+    {
+        get
+        {
+            var sb = new System.Text.StringBuilder();
+            foreach (var c in _kids) sb.Append(c.StringValue);
+            return sb.ToString();
+        }
+    }
+
+    public override string ToString()
+    {
+        var first = _kids.OfType<AdapterElement>().FirstOrDefault();
+        return $"document {{ {first?.NodeName?.LocalName ?? "(empty)"} }}";
+    }
+
+    public static AdapterDocument Build(IEnumerable<UnvParseTreeNode> roots)
+    {
+        var doc = new AdapterDocument();
+        foreach (var root in roots)
+        {
+            if (root is UnvParseTreeElement elem)
+                doc._kids.Add(AdapterElement.Build(elem, doc));
+        }
+        return doc;
+    }
+}
+
+/// <summary>
+/// Wraps a UnvParseTreeElement as an XdmElement. Carries a back-reference
+/// to the original Source node so results can be re-serialised.
+/// </summary>
+sealed class AdapterElement : XdmElement
+{
+    public UnvParseTreeElement Source { get; }
+    private readonly List<XdmNode> _kids = new();
+    private readonly List<XdmAttribute> _attrs = new();
+
+    AdapterElement(UnvParseTreeElement source) : base(source.LocalName ?? "")
+    {
+        Source = source;
+    }
+
+    public override IReadOnlyList<XdmNode> Children => _kids;
+    public override IReadOnlyList<XdmAttribute> Attributes => _attrs;
+
+    public override string StringValue
+    {
+        get
+        {
+            var sb = new System.Text.StringBuilder();
+            CollectText(sb);
+            return sb.ToString();
+        }
+    }
+
+    private void CollectText(System.Text.StringBuilder sb)
+    {
+        foreach (var child in _kids)
+        {
+            if (child is AdapterText t) sb.Append(t.StringValue);
+            else if (child is AdapterElement e) e.CollectText(sb);
+        }
+    }
+
+    public static AdapterElement Build(UnvParseTreeElement source, XdmNode parent)
+    {
+        var elem = new AdapterElement(source);
+        elem.Parent = parent;
+
+        foreach (Node child in source.AllChildren)
+        {
+            switch (child)
+            {
+                case UnvParseTreeElement childElem:
+                    elem._kids.Add(AdapterElement.Build(childElem, elem));
+                    break;
+                case UnvParseTreeText childText:
+                    var t = new AdapterText(childText);
+                    t.Parent = elem;
+                    elem._kids.Add(t);
+                    break;
+                case UnvParseTreeAttr childAttr:
+                    var a = new AdapterAttribute(childAttr);
+                    a.Parent = elem;
+                    elem._attrs.Add(a);
+                    break;
+            }
+        }
+
+        return elem;
+    }
+}
+
+/// <summary>
+/// Wraps a UnvParseTreeAttr as an XdmAttribute.
+/// </summary>
+sealed class AdapterAttribute : XdmAttribute
+{
+    public UnvParseTreeAttr Source { get; }
+
+    public AdapterAttribute(UnvParseTreeAttr source)
+        : base(source.LocalName ?? source.Name?.ToString() ?? "", source.StringValue ?? "")
+    {
+        Source = source;
+    }
+}
+
+/// <summary>
+/// Wraps a UnvParseTreeText as an XdmText.
+/// </summary>
+sealed class AdapterText : XdmText
+{
+    public UnvParseTreeText Source { get; }
+
+    public AdapterText(UnvParseTreeText source) : base(source.Data ?? "")
+    {
+        Source = source;
+    }
+}

--- a/src/trsort/readme.md
+++ b/src/trsort/readme.md
@@ -12,28 +12,33 @@ to stdout. The input and output are Parse Tree Data.
 
 ## Usage
 
-    trsort bfs <string>
-    trsort dfs <string>
+    trsort [-a]
+    trsort --bfs [<start-rule>]
+    trsort --dfs [<start-rule>]
 
 ## Details
 
-Reorder the parser rules according to the specified type and start rule.
-For BFS and DFS, an XPath expression must be supplied to specify all the start
-rule symbols. For alphabetic reordering, all parser rules are retained, and
-simply reordered alphabetically. For BFS and DFS, if the rule is unreachable
-from a start node set that is specified via <string>, then the rule is dropped
-from the grammar.
+Reorder the parser rules according to the specified mode.
+
+`-a` / `--alphabetic` (default when no mode flag is given): sort all parser
+rules alphabetically. All rules are retained.
+
+`--bfs [<start-rule>]`: sort reachable parser rules in breadth-first order
+from the named start rule. Rules not reachable from the start rule are dropped.
+If `<start-rule>` is omitted, the start rule is auto-detected by finding the
+parser rule whose alternative contains an `EOF` token; an error is reported if
+zero or more than one such rule exists.
+
+`--dfs [<start-rule>]`: same as `--bfs` but uses depth-first (preorder)
+traversal.
+
+Only one mode flag may be specified at a time.
 
 ## Example
 
-    trparse Java.g4 | trsort alpha | trtext
-    trparse Java.g4 | trsort dfs ""//parserRuleSpec/RULE_REF[text()='libraryDefinition']"" | trtext
-
-## Notes
-
-If you are running MSYS2 on Windows, you may notice that XPaths are not being
-processed by this command correctly. To avoid the Bash shell from altering
-XPaths, type _export MSYS2_ARG_CONV_EXCL="*"_, then execute your command.
+    dotnet trash parse Java.g4 | dotnet trash trsort -a | dotnet trash sponge -o out -c
+    dotnet trash parse Java.g4 | dotnet trash trsort --dfs compilationUnit | dotnet trash sponge -o out -c
+    dotnet trash parse Java.g4 | dotnet trash trsort --bfs | dotnet trash sponge -o out -c
 
 ## Current version
 

--- a/src/trsort/trsort.csproj
+++ b/src/trsort/trsort.csproj
@@ -31,6 +31,9 @@ This program is part of the Trash toolkit.]]>
 		<ProjectReference Include="../AntlrJson/AntlrJson.csproj" />
 		<ProjectReference Include="../ParseTreeEditing/ParseTreeEditing.csproj" />
 		<ProjectReference Include="../Logger/Logger.csproj" />
+		<ProjectReference Include="../xquery4/src/XQuery.DataModel/XQuery.DataModel.csproj" />
+		<ProjectReference Include="../xquery4/src/XQuery.Parser/XQuery.Parser.csproj" />
+		<ProjectReference Include="../xquery4/src/XQuery.Engine/XQuery.Engine.csproj" />
 	</ItemGroup>
 	<ItemGroup>
 		<None Include="readme.md" Pack="true" PackagePath=""/>

--- a/src/xquery4/src/XQuery.DataModel/XdmNode.cs
+++ b/src/xquery4/src/XQuery.DataModel/XdmNode.cs
@@ -1,6 +1,7 @@
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("trxpath")]
+[assembly: InternalsVisibleTo("trsort")]
 
 namespace XQuery.DataModel;
 


### PR DESCRIPTION
Replace the fully-commented-out CReorder.cs with a working implementation using ParseTreeEditing.UnvParseTreeDOM:

- CReorder.AlphaSort: sorts all parser rules alphabetically by inserting in descending order at position 0, yielding ascending output order.
- CReorder.BfsSort/DfsSort: build a directed rule-reference graph, traverse from start rules identified by a user-supplied XPath expression, drop unreachable rules, and reorder the rest in BFS/DFS preorder.

Command.cs: remove stale imports (internal.ast, Antlr4.Runtime.Misc, org.eclipse.wst.xml.xpath2.processor.util), replace the inline partial alpha-sort with dispatch to CReorder based on --bfs/--dfs flags.

Config.cs: add [Value(0)] Expr for the BFS/DFS XPath expression, remove unused Bottom/Top options, add help text.