### PR TITLE
trunfoldlit: migrate XPath engine to XPathEvaluator (xquery4)

### DIFF
--- a/src/trunfoldlit/Command.cs
+++ b/src/trunfoldlit/Command.cs
@@ -69,10 +69,10 @@ class Command
         var tokenRefItems = evaluator.Evaluate(exprNode1, adapterDoc).ToList();
         if (config.Verbose) LoggerNs.TimedStderrOutput.WriteLine("Found " + tokenRefItems.Count + " TOKEN_REF nodes.");
 
-        // ── Step 2: collect all non-fragment lexer rules whose body is exactly one
-        //           string literal, then keep only those with a *unique* literal
-        //           across all such rules (rules in different lexer modes can share
-        //           the same literal, so those must be excluded). ──────────────────
+        // ── Step 2a: find candidate lexer rules — non-fragment, single alternative
+        //            with no lexer commands, body is exactly one string literal.
+        //            Rules like `ET_EQ : '=' -> type(EQ);` are intentionally
+        //            excluded here (they have commands and must not be inlined). ──
         var expr2 =
             "//lexerRuleSpec[not(FRAGMENT)]" +
             "[lexerRuleBlock/lexerAltList[count(*) = 1]/lexerAlt[count(*) = 1]" +
@@ -104,11 +104,35 @@ class Command
             candidates.Add((tokenRefAe.StringValue, litAe.StringValue, blockAe.Source));
         }
 
-        // Only inline tokens whose string literal is unique across all candidates.
+        // ── Step 2b: collect ALL string literals from ALL non-fragment lexer rule
+        //            bodies across every mode and file.  This catches rules like
+        //            `ET_EQ : '=' -> type(EQ);` that share a literal with a
+        //            candidate but were excluded from Step 2a due to their command.
+        //            A candidate is only inlined when its literal appears exactly
+        //            once in this full set. ─────────────────────────────────────
+        var expr3 =
+            "//lexerRuleSpec[not(FRAGMENT)]" +
+            "/lexerRuleBlock/lexerAltList/lexerAlt" +
+            "/lexerElements/lexerElement/lexerAtom/terminalDef/STRING_LITERAL";
+        if (config.Verbose) System.Console.Error.WriteLine("Expr3 = >>>" + expr3 + "<<<");
+        var exprNode3 = new XPathParser(expr3).Parse();
+        var allLitItems = evaluator.Evaluate(exprNode3, adapterDoc).ToList();
+
+        var nonUniqueLits = allLitItems
+            .OfType<AdapterElement>()
+            .Select(ae => ae.StringValue)
+            .GroupBy(s => s)
+            .Where(g => g.Count() > 1)
+            .Select(g => g.Key)
+            .ToHashSet();
+
+        if (config.Verbose) LoggerNs.TimedStderrOutput.WriteLine(
+            nonUniqueLits.Count + " string literal(s) are shared across multiple lexer rules and will not be inlined.");
+
+        // Only inline candidates whose literal is unique across ALL lexer rule bodies.
         var uniqueRules = candidates
-            .GroupBy(c => c.lit)
-            .Where(g => g.Count() == 1)
-            .ToDictionary(g => g.First().name, g => g.First().block);
+            .Where(c => !nonUniqueLits.Contains(c.lit))
+            .ToDictionary(c => c.name, c => c.block);
 
         if (config.Verbose) LoggerNs.TimedStderrOutput.WriteLine(
             uniqueRules.Count + " lexer rules have a unique string literal and will be inlined.");

--- a/src/trunfoldlit/Command.cs
+++ b/src/trunfoldlit/Command.cs
@@ -1,10 +1,12 @@
-﻿using AntlrJson;
-using org.eclipse.wst.xml.xpath2.processor.util;
+using AntlrJson;
 using ParseTreeEditing.UnvParseTreeDOM;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text.Json;
+using XQuery.DataModel;
+using XQuery.Engine;
+using XPathParser = XQuery.Parser.XPathParser;
 
 namespace Trash;
 
@@ -21,19 +23,11 @@ class Command
 
     public void Execute(Config config)
     {
-        var expr = "//parserRuleSpec//atom/terminalDef/TOKEN_REF";
-        if (config.Verbose)
-        {
-            System.Console.Error.WriteLine("Expr = >>>" + expr + "<<<");
-        }
-
         string lines = null;
         if (!(config.File != null && config.File != ""))
         {
             if (config.Verbose)
-            {
                 System.Console.Error.WriteLine("reading from stdin");
-            }
 
             for (;;)
             {
@@ -46,9 +40,7 @@ class Command
         else
         {
             if (config.Verbose)
-            {
                 System.Console.Error.WriteLine("reading from file >>>" + config.File + "<<<");
-            }
 
             lines = File.ReadAllText(config.File);
         }
@@ -60,67 +52,125 @@ class Command
         if (config.Verbose) LoggerNs.TimedStderrOutput.WriteLine("starting deserialization");
         var data = JsonSerializer.Deserialize<AntlrJson.ParsingResultSet[]>(lines, serializeOptions);
         if (config.Verbose) LoggerNs.TimedStderrOutput.WriteLine("deserialized");
+
+        // Build one combined AdapterDocument from all trees across all parse_infos.
+        // This enables cross-document querying: token names used in parser rules in
+        // one file can be matched against lexer rules defined in a separate file
+        // (e.g. a lexer grammar with modes).
+        var allTrees = data.SelectMany(pi => pi.Nodes).ToList();
+        var adapterDoc = AdapterDocument.Build(allTrees);
+
+        var evaluator = new XPathEvaluator();
+
+        // ── Step 1: find every TOKEN_REF appearing inside a parser rule. ──────────
+        var expr1 = "//parserRuleSpec//atom/terminalDef/TOKEN_REF";
+        if (config.Verbose) System.Console.Error.WriteLine("Expr1 = >>>" + expr1 + "<<<");
+        var exprNode1 = new XPathParser(expr1).Parse();
+        var tokenRefItems = evaluator.Evaluate(exprNode1, adapterDoc).ToList();
+        if (config.Verbose) LoggerNs.TimedStderrOutput.WriteLine("Found " + tokenRefItems.Count + " TOKEN_REF nodes.");
+
+        // ── Step 2: collect all non-fragment lexer rules whose body is exactly one
+        //           string literal, then keep only those with a *unique* literal
+        //           across all such rules (rules in different lexer modes can share
+        //           the same literal, so those must be excluded). ──────────────────
+        var expr2 =
+            "//lexerRuleSpec[not(FRAGMENT)]" +
+            "[lexerRuleBlock/lexerAltList[count(*) = 1]/lexerAlt[count(*) = 1]" +
+            "/lexerElements[count(*) = 1]/lexerElement[count(*) = 1]" +
+            "/lexerAtom/terminalDef[count(*) = 1]/STRING_LITERAL]";
+        if (config.Verbose) System.Console.Error.WriteLine("Expr2 = >>>" + expr2 + "<<<");
+        var exprNode2 = new XPathParser(expr2).Parse();
+        var lexerSpecItems = evaluator.Evaluate(exprNode2, adapterDoc).ToList();
+        if (config.Verbose) LoggerNs.TimedStderrOutput.WriteLine("Found " + lexerSpecItems.Count + " candidate lexer rules.");
+
+        // For each qualifying lexerRuleSpec, extract the token name, the string
+        // literal text, and the lexerRuleBlock node that will be used for replacement.
+        var candidates = new List<(string name, string lit, UnvParseTreeElement block)>();
+        foreach (var specItem in lexerSpecItems)
+        {
+            if (specItem is not AdapterElement specAe) continue;
+
+            var tokenRefAe = specAe.Children.OfType<AdapterElement>()
+                .FirstOrDefault(c => c.NodeName?.LocalName == "TOKEN_REF");
+            var blockAe = specAe.Children.OfType<AdapterElement>()
+                .FirstOrDefault(c => c.NodeName?.LocalName == "lexerRuleBlock");
+            if (tokenRefAe == null || blockAe == null) continue;
+
+            var litAe = DescendChild(blockAe,
+                "lexerAltList", "lexerAlt", "lexerElements",
+                "lexerElement", "lexerAtom", "terminalDef", "STRING_LITERAL");
+            if (litAe == null) continue;
+
+            candidates.Add((tokenRefAe.StringValue, litAe.StringValue, blockAe.Source));
+        }
+
+        // Only inline tokens whose string literal is unique across all candidates.
+        var uniqueRules = candidates
+            .GroupBy(c => c.lit)
+            .Where(g => g.Count() == 1)
+            .ToDictionary(g => g.First().name, g => g.First().block);
+
+        if (config.Verbose) LoggerNs.TimedStderrOutput.WriteLine(
+            uniqueRules.Count + " lexer rules have a unique string literal and will be inlined.");
+
+        // ── Step 3: replace each qualifying TOKEN_REF with the lexerRuleBlock. ───
+        foreach (var item in tokenRefItems)
+        {
+            if (item is not AdapterElement ae) continue;
+            var node = ae.Source;
+            var name = node.GetText();
+
+            if (!uniqueRules.TryGetValue(name, out var defBlock)) continue;
+
+            if (config.Verbose)
+                System.Console.Error.WriteLine("Inlining " + name);
+
+            var copy = TreeEdits.CopyTreeRecursive(defBlock);
+            TreeEdits.InsertBefore(node, copy);
+            TreeEdits.Delete(node);
+        }
+
+        if (config.Verbose)
+        {
+            System.Console.Error.WriteLine("Final trees:");
+            foreach (var parse_info in data)
+            {
+                var lexer = parse_info.Lexer;
+                var parser = parse_info.Parser;
+                foreach (var n in parse_info.Nodes)
+                    System.Console.WriteLine(new TreeOutput(lexer, parser).OutputTree(n).ToString());
+            }
+        }
+
         var results = new List<ParsingResultSet>();
         foreach (var parse_info in data)
         {
-            var fn = parse_info.FileName;
-            var trees = parse_info.Nodes;
-            var parser = parse_info.Parser;
-            var lexer = parse_info.Lexer;
-            if (config.Verbose)
+            results.Add(new ParsingResultSet()
             {
-                foreach (var n in trees)
-                    System.Console.WriteLine(new TreeOutput(lexer, parser).OutputTree(n).ToString());
-            }
-
-            org.eclipse.wst.xml.xpath2.processor.Engine engine = new org.eclipse.wst.xml.xpath2.processor.Engine();
-            var ate = new ParseTreeEditing.UnvParseTreeDOM.ConvertToDOM();
-            using (AntlrDynamicContext dynamicContext = ate.Try(trees, parser))
-            {
-                var nodes = engine.parseExpression(expr,
-                        new StaticContextBuilder()).evaluate(dynamicContext, new object[] { dynamicContext.Document })
-                    .Select(x => (x.NativeValue as ParseTreeEditing.UnvParseTreeDOM.UnvParseTreeElement)).ToList();
-                if (config.Verbose) LoggerNs.TimedStderrOutput.WriteLine("Found " + nodes.Count + " nodes.");
-                foreach (UnvParseTreeElement node in nodes)
-                {
-                    // Find parser or lexer rule.
-                    var name = node.GetText();
-                    var exp = $" doc('*')//lexerRuleSpec[TOKEN_REF/text()='{name}' and not(FRAGMENT)]/lexerRuleBlock[lexerAltList[count(*) = 1]/lexerAlt[count(*) = 1]/lexerElements[count(*) = 1]/lexerElement[count(*) = 1]/lexerAtom/terminalDef[count(*) = 1]/STRING_LITERAL]";
-                    var defs = engine.parseExpression(exp,
-                            new StaticContextBuilder())
-                        .evaluate(dynamicContext, new object[] { dynamicContext.Document })
-                        .Select(x => (x.NativeValue as ParseTreeEditing.UnvParseTreeDOM.UnvParseTreeElement)).ToList();
-                    if (config.Verbose) LoggerNs.TimedStderrOutput.WriteLine("Found " + defs.Count + " defs.");
-                    if (defs.Count != 1) continue;
-                    var copy = TreeEdits.CopyTreeRecursive(defs.First());
-                    //TreeEdits.InsertBefore(node, "(");
-                    //TreeEdits.InsertAfter(node, ")");
-                    // Replace
-                    TreeEdits.InsertBefore(node, copy);
-                    TreeEdits.Delete(node);
-                }
-
-                if (config.Verbose)
-                {
-                    System.Console.Error.WriteLine("Final trees:");
-                    foreach (var n in trees)
-                        System.Console.WriteLine(new TreeOutput(lexer, parser).OutputTree(n).ToString());
-                }
-
-                var tuple = new ParsingResultSet()
-                {
-                    FileName = fn,
-                    Nodes = trees,
-                    Lexer = lexer,
-                    Parser = parser
-                };
-                results.Add(tuple);
-            }
+                FileName = parse_info.FileName,
+                Nodes = parse_info.Nodes,
+                Lexer = parse_info.Lexer,
+                Parser = parse_info.Parser
+            });
         }
 
         if (config.Verbose) LoggerNs.TimedStderrOutput.WriteLine("starting serialization");
         string js1 = JsonSerializer.Serialize(results.ToArray(), serializeOptions);
         if (config.Verbose) LoggerNs.TimedStderrOutput.WriteLine("serialized");
         System.Console.WriteLine(js1);
+    }
+
+    /// <summary>
+    /// Drills down through a chain of element names, returning the innermost match or null.
+    /// </summary>
+    private static AdapterElement? DescendChild(AdapterElement parent, params string[] names)
+    {
+        AdapterElement? current = parent;
+        foreach (var name in names)
+        {
+            current = current?.Children.OfType<AdapterElement>()
+                .FirstOrDefault(c => c.NodeName?.LocalName == name);
+        }
+        return current;
     }
 }

--- a/src/trunfoldlit/UnvToXdmAdapter.cs
+++ b/src/trunfoldlit/UnvToXdmAdapter.cs
@@ -1,0 +1,138 @@
+using System.Collections.Generic;
+using System.Linq;
+using org.w3c.dom;
+using ParseTreeEditing.UnvParseTreeDOM;
+using XQuery.DataModel;
+
+namespace Trash;
+
+/// <summary>
+/// Wraps a set of UnvParseTreeNode roots as an XdmDocument so the xquery4
+/// engine can navigate the parse tree using standard XPath axes.
+/// </summary>
+sealed class AdapterDocument : XdmDocument
+{
+    private readonly List<XdmNode> _kids = new();
+
+    public override IReadOnlyList<XdmNode> Children => _kids;
+
+    public override string StringValue
+    {
+        get
+        {
+            var sb = new System.Text.StringBuilder();
+            foreach (var c in _kids) sb.Append(c.StringValue);
+            return sb.ToString();
+        }
+    }
+
+    public override string ToString()
+    {
+        var first = _kids.OfType<AdapterElement>().FirstOrDefault();
+        return $"document {{ {first?.NodeName?.LocalName ?? "(empty)"} }}";
+    }
+
+    public static AdapterDocument Build(IEnumerable<UnvParseTreeNode> roots)
+    {
+        var doc = new AdapterDocument();
+        foreach (var root in roots)
+        {
+            if (root is UnvParseTreeElement elem)
+                doc._kids.Add(AdapterElement.Build(elem, doc));
+        }
+        return doc;
+    }
+}
+
+/// <summary>
+/// Wraps a UnvParseTreeElement as an XdmElement. Carries a back-reference
+/// to the original Source node so results can be re-serialised.
+/// </summary>
+sealed class AdapterElement : XdmElement
+{
+    public UnvParseTreeElement Source { get; }
+    private readonly List<XdmNode> _kids = new();
+    private readonly List<XdmAttribute> _attrs = new();
+
+    AdapterElement(UnvParseTreeElement source) : base(source.LocalName ?? "")
+    {
+        Source = source;
+    }
+
+    public override IReadOnlyList<XdmNode> Children => _kids;
+    public override IReadOnlyList<XdmAttribute> Attributes => _attrs;
+
+    public override string StringValue
+    {
+        get
+        {
+            var sb = new System.Text.StringBuilder();
+            CollectText(sb);
+            return sb.ToString();
+        }
+    }
+
+    private void CollectText(System.Text.StringBuilder sb)
+    {
+        foreach (var child in _kids)
+        {
+            if (child is AdapterText t) sb.Append(t.StringValue);
+            else if (child is AdapterElement e) e.CollectText(sb);
+        }
+    }
+
+    public static AdapterElement Build(UnvParseTreeElement source, XdmNode parent)
+    {
+        var elem = new AdapterElement(source);
+        elem.Parent = parent;
+
+        foreach (Node child in source.AllChildren)
+        {
+            switch (child)
+            {
+                case UnvParseTreeElement childElem:
+                    elem._kids.Add(AdapterElement.Build(childElem, elem));
+                    break;
+                case UnvParseTreeText childText:
+                    var t = new AdapterText(childText);
+                    t.Parent = elem;
+                    elem._kids.Add(t);
+                    break;
+                case UnvParseTreeAttr childAttr:
+                    var a = new AdapterAttribute(childAttr);
+                    a.Parent = elem;
+                    elem._attrs.Add(a);
+                    break;
+            }
+        }
+
+        return elem;
+    }
+}
+
+/// <summary>
+/// Wraps a UnvParseTreeAttr as an XdmAttribute.
+/// </summary>
+sealed class AdapterAttribute : XdmAttribute
+{
+    public UnvParseTreeAttr Source { get; }
+
+    public AdapterAttribute(UnvParseTreeAttr source)
+        : base(source.LocalName ?? source.Name?.ToString() ?? "", source.StringValue ?? "")
+    {
+        Source = source;
+    }
+}
+
+/// <summary>
+/// Wraps a UnvParseTreeText as an XdmText.
+/// </summary>
+sealed class AdapterText : XdmText
+{
+    public UnvParseTreeText Source { get; }
+
+    public AdapterText(UnvParseTreeText source) : base(source.Data ?? "")
+    {
+        Source = source;
+    }
+}

--- a/src/trunfoldlit/trunfoldlit.csproj
+++ b/src/trunfoldlit/trunfoldlit.csproj
@@ -32,6 +32,9 @@ in the parse tree. This program is part of the Trash toolkit.
 		<ProjectReference Include="../AntlrJson/AntlrJson.csproj" />
 		<ProjectReference Include="../ParseTreeEditing/ParseTreeEditing.csproj" />
 		<ProjectReference Include="../Logger/Logger.csproj" />
+		<ProjectReference Include="../xquery4/src/XQuery.DataModel/XQuery.DataModel.csproj" />
+		<ProjectReference Include="../xquery4/src/XQuery.Parser/XQuery.Parser.csproj" />
+		<ProjectReference Include="../xquery4/src/XQuery.Engine/XQuery.Engine.csproj" />
 	</ItemGroup>
 	<ItemGroup>
 		<None Include="readme.md" Pack="true" PackagePath=""/>

--- a/src/xquery4/src/XQuery.DataModel/XdmNode.cs
+++ b/src/xquery4/src/XQuery.DataModel/XdmNode.cs
@@ -2,6 +2,7 @@ using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("trxpath")]
 [assembly: InternalsVisibleTo("trsort")]
+[assembly: InternalsVisibleTo("trunfoldlit")]
 
 namespace XQuery.DataModel;
 


### PR DESCRIPTION
## Summary

- Replaces the Eclipse XPath2 engine with the xquery4 `XPathEvaluator` in `trunfoldlit`
- Builds one combined `AdapterDocument` from all parse trees across all input files, enabling cross-file token lookups (fixes the modes case where parser and lexer grammars are in separate files)
- Uniqueness check is now done in C# via two separate queries rather than a nested XPath `count()` per TOKEN_REF — O(n) instead of O(n²)
- **Fixes modes bug:** rules like `ET_EQ : '=' -> type(EQ);` were previously invisible to the uniqueness check because they fail the candidate filter (commands must not be inlined). A second broad query now collects ALL string literals from ALL non-fragment lexer rule bodies across every mode and file, so shared literals are correctly detected and excluded from inlining regardless of rule structure.

## Test plan

- [ ] `trparse *.g4 | trunfoldlit` on `g4-current/abb` (single lexer grammar, no modes) — inlines correctly
- [ ] `trparse *.g4 | trunfoldlit` on `g4-xquery/xquery/xquery4` (lexer grammar with modes, shared string literals) — shared-literal rules (e.g. `EQ`/`ET_EQ` both using `'='`) are excluded; unique-literal rules are inlined correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)