### PR TITLE
trinterp: add ATN state → .g4 source location mapping

### DIFF
--- a/src/trinterp/ATNState.cs
+++ b/src/trinterp/ATNState.cs
@@ -6,6 +6,10 @@ public abstract class ATNState
 {
     public int stateNumber = -1;
     public int ruleIndex = -1;
+    /// <summary>1-based line in the .g4 source, or -1 if unavailable.</summary>
+    public int SourceLine = -1;
+    /// <summary>0-based column in the .g4 source, or -1 if unavailable.</summary>
+    public int SourceColumn = -1;
     private readonly List<Transition> _transitions = new();
 
     public abstract StateType StateType { get; }

--- a/src/trinterp/ATNState.cs
+++ b/src/trinterp/ATNState.cs
@@ -6,10 +6,17 @@ public abstract class ATNState
 {
     public int stateNumber = -1;
     public int ruleIndex = -1;
-    /// <summary>1-based line in the .g4 source, or -1 if unavailable.</summary>
+    /// <summary>1-based line of the grammar element that enters this state, or -1 if unavailable.</summary>
     public int SourceLine = -1;
-    /// <summary>0-based column in the .g4 source, or -1 if unavailable.</summary>
+    /// <summary>0-based column of the grammar element that enters this state, or -1 if unavailable.</summary>
     public int SourceColumn = -1;
+    /// <summary>
+    /// Exclusive end position of the grammar element whose non-epsilon outgoing transition
+    /// leaves this state. Populated only for "match" states; -1 otherwise.
+    /// Used by StateLocationMap to compute post-transition locations.
+    /// </summary>
+    public int SourceEndLine = -1;
+    public int SourceEndColumn = -1;
     private readonly List<Transition> _transitions = new();
 
     public abstract StateType StateType { get; }

--- a/src/trinterp/AtnDotWriter.cs
+++ b/src/trinterp/AtnDotWriter.cs
@@ -265,6 +265,9 @@ public static class AtnDotWriter
 
                 if (!included.Contains(target)) continue;
                 bool isEpsilon = tr is EpsilonTransition;
+                // Append source location to non-epsilon edge labels.
+                if (!isEpsilon && s.SourceLine >= 0)
+                    label += $"\n{s.SourceLine}:{s.SourceColumn}";
                 // Dashed style for loopback edges.
                 bool isDashed = s is StarLoopbackState ||
                                 (s is PlusLoopbackState && target.stateNumber < s.stateNumber);

--- a/src/trinterp/AtnDotWriter.cs
+++ b/src/trinterp/AtnDotWriter.cs
@@ -51,8 +51,9 @@ public static class AtnDotWriter
     public static string FormatStateMap(GrammarModel grammar, ATN atn, StateLocationMap lm)
     {
         var sb = new System.Text.StringBuilder();
-        sb.AppendLine();
-        sb.AppendLine("state map:");
+        sb.Append('\n');           // end the atn: data line (Serialize uses Append, no trailing \n)
+        sb.Append('\n');           // blank line before section
+        sb.Append("state map:\n");
         foreach (var s in atn.states)
         {
             if (s == null) continue;
@@ -63,9 +64,9 @@ public static class AtnDotWriter
             string locsStr = locs.Count == 0
                 ? "-"
                 : string.Join(";", Sorted(locs).Select(l => $"{l.Line}:{l.Col}"));
-            sb.AppendLine($"{s.stateNumber}\t{ruleName}\t{locsStr}");
+            sb.Append($"{s.stateNumber}\t{ruleName}\t{locsStr}\n");
         }
-        sb.AppendLine();
+        sb.Append('\n');
         return sb.ToString();
     }
 

--- a/src/trinterp/AtnDotWriter.cs
+++ b/src/trinterp/AtnDotWriter.cs
@@ -42,17 +42,17 @@ public static class AtnDotWriter
     }
 
     /// <summary>
-    /// Writes a tab-separated state map to &lt;grammarName&gt;.state-map.tsv.
+    /// Formats the state map as a "state map:" section suitable for appending to a .interp file.
     /// Each row: stateNumber TAB ruleName TAB locations
     /// where locations is a semicolon-separated list of "line:col" pairs (1-based line,
     /// 0-based col), or "-" when no source location is available.
     /// Requires trparse -l to have been used; otherwise all locations will be "-".
     /// </summary>
-    public static void WriteStateMap(GrammarModel grammar, ATN atn, string outDir,
-                                     StateLocationMap lm)
+    public static string FormatStateMap(GrammarModel grammar, ATN atn, StateLocationMap lm)
     {
         var sb = new System.Text.StringBuilder();
-        sb.AppendLine("state\trule\tlocations");
+        sb.AppendLine();
+        sb.AppendLine("state map:");
         foreach (var s in atn.states)
         {
             if (s == null) continue;
@@ -65,8 +65,8 @@ public static class AtnDotWriter
                 : string.Join(";", Sorted(locs).Select(l => $"{l.Line}:{l.Col}"));
             sb.AppendLine($"{s.stateNumber}\t{ruleName}\t{locsStr}");
         }
-        var path = Path.Combine(outDir, grammar.Name + ".state-map.tsv");
-        File.WriteAllText(path, sb.ToString());
+        sb.AppendLine();
+        return sb.ToString();
     }
 
     // ---- per-rule digraph ---------------------------------------------------

--- a/src/trinterp/AtnDotWriter.cs
+++ b/src/trinterp/AtnDotWriter.cs
@@ -38,6 +38,27 @@ public static class AtnDotWriter
         File.WriteAllText(path, dot);
     }
 
+    /// <summary>
+    /// Writes a tab-separated state map to &lt;grammarName&gt;.state-map.tsv.
+    /// Each row: stateNumber TAB ruleName TAB line TAB col
+    /// Line/col are -1 when trparse was not invoked with -l.
+    /// </summary>
+    public static void WriteStateMap(GrammarModel grammar, ATN atn, string outDir)
+    {
+        var sb = new System.Text.StringBuilder();
+        sb.AppendLine("state\trule\tline\tcol");
+        foreach (var s in atn.states)
+        {
+            if (s == null) continue;
+            string ruleName = s.ruleIndex >= 0 && s.ruleIndex < grammar.Rules.Count
+                ? grammar.Rules[s.ruleIndex].Name
+                : "(none)";
+            sb.AppendLine($"{s.stateNumber}\t{ruleName}\t{s.SourceLine}\t{s.SourceColumn}");
+        }
+        var path = Path.Combine(outDir, grammar.Name + ".state-map.tsv");
+        File.WriteAllText(path, sb.ToString());
+    }
+
     // ---- per-rule digraph ---------------------------------------------------
 
     private static string RuleToDot(string ruleName, RuleStartState start, RuleStopState stop,
@@ -105,7 +126,8 @@ public static class AtnDotWriter
     {
         foreach (var s in states)
         {
-            string nodeId = $"s{s.stateNumber}";
+            string nodeId  = $"s{s.stateNumber}";
+            string tooltip = StateTooltip(s);
             // StarBlockStartState and PlusBlockStartState are always circles even when
             // they appear in decisionToState (multi-alt case); check them before the
             // generic DecisionState branch below.
@@ -119,12 +141,12 @@ public static class AtnDotWriter
                     var ports = new StringBuilder();
                     for (int pi = 0; pi < n; pi++) { if (pi > 0) ports.Append('|'); ports.Append($"<p{pi}>"); }
                     string label = $"{{&rarr;\\n{s.stateNumber}{symbol}\\nd={dLoop}|{{{ports}}}}}";
-                    sb.AppendLine($"{nodeId}[fontsize=11,label=\"{label}\", shape=record, fixedsize=false, peripheries=1];");
+                    sb.AppendLine($"{nodeId}[fontsize=11,label=\"{label}\", shape=record, fixedsize=false, peripheries=1{tooltip}];");
                 }
                 else
                 {
                     string label = $"&rarr;\\n{s.stateNumber}{symbol}";
-                    sb.AppendLine($"{nodeId}[fontsize=11,label=\"{label}\", shape=circle, fixedsize=true, width=.55, peripheries=1];");
+                    sb.AppendLine($"{nodeId}[fontsize=11,label=\"{label}\", shape=circle, fixedsize=true, width=.55, peripheries=1{tooltip}];");
                 }
                 continue;
             }
@@ -150,38 +172,48 @@ public static class AtnDotWriter
                     label = $"{{{s.stateNumber}+\\nd={d}|{{{ports}}}}}";
                 else
                     label = $"{{{s.stateNumber}\\nd={d}|{{{ports}}}}}";
-                sb.AppendLine($"{nodeId}[fontsize=11,label=\"{label}\", shape=record, fixedsize=false, peripheries=1];");
+                sb.AppendLine($"{nodeId}[fontsize=11,label=\"{label}\", shape=record, fixedsize=false, peripheries=1{tooltip}];");
             }
             else if (s is BasicBlockStartState || s is TokensStartState)
             {
                 // Block start collapsed to a single alt by OptimizeSets and removed from
                 // decisionToState: render as BLOCK_START circle (→\nN, no decision ports).
-                sb.AppendLine($"{nodeId}[fontsize=11,label=\"&rarr;\\n{s.stateNumber}\", shape=circle, fixedsize=true, width=.55, peripheries=1];");
+                sb.AppendLine($"{nodeId}[fontsize=11,label=\"&rarr;\\n{s.stateNumber}\", shape=circle, fixedsize=true, width=.55, peripheries=1{tooltip}];");
             }
             else if (s is StarLoopbackState)
             {
                 string label = $"{s.stateNumber}*";
-                sb.AppendLine($"{nodeId}[fontsize=11,label=\"{label}\", shape=circle, fixedsize=true, width=.55, peripheries=1];");
+                sb.AppendLine($"{nodeId}[fontsize=11,label=\"{label}\", shape=circle, fixedsize=true, width=.55, peripheries=1{tooltip}];");
             }
             else if (s is BlockEndState)
             {
                 string label = $"&larr;\\n{s.stateNumber}";
-                sb.AppendLine($"{nodeId}[fontsize=11,label=\"{label}\", shape=circle, fixedsize=true, width=.55, peripheries=1];");
+                sb.AppendLine($"{nodeId}[fontsize=11,label=\"{label}\", shape=circle, fixedsize=true, width=.55, peripheries=1{tooltip}];");
             }
             else if (s is LoopEndState)
             {
                 // LoopEnd is a plain circle — no '←' prefix.
-                sb.AppendLine($"{nodeId}[fontsize=11,label=\"{s.stateNumber}\", shape=circle, fixedsize=true, width=.55, peripheries=1];");
+                sb.AppendLine($"{nodeId}[fontsize=11,label=\"{s.stateNumber}\", shape=circle, fixedsize=true, width=.55, peripheries=1{tooltip}];");
             }
             else if (s is RuleStopState)
             {
-                sb.AppendLine($"{nodeId}[fontsize=11, label=\"{s.stateNumber}\", shape=doublecircle, fixedsize=true, width=.6];");
+                sb.AppendLine($"{nodeId}[fontsize=11, label=\"{s.stateNumber}\", shape=doublecircle, fixedsize=true, width=.6{tooltip}];");
             }
             else
             {
-                sb.AppendLine($"{nodeId}[fontsize=11,label=\"{s.stateNumber}\", shape=circle, fixedsize=true, width=.55, peripheries=1];");
+                sb.AppendLine($"{nodeId}[fontsize=11,label=\"{s.stateNumber}\", shape=circle, fixedsize=true, width=.55, peripheries=1{tooltip}];");
             }
         }
+    }
+
+    /// <summary>
+    /// Returns a DOT tooltip attribute string for <paramref name="s"/> when source location
+    /// is available, e.g. <c>, tooltip="line 5, col 3"</c>. Returns empty string otherwise.
+    /// </summary>
+    private static string StateTooltip(ATNState s)
+    {
+        if (s.SourceLine < 0) return string.Empty;
+        return $", tooltip=\"line {s.SourceLine}, col {s.SourceColumn}\"";
     }
 
     private static void AppendEdges(StringBuilder sb, IEnumerable<ATNState> states,

--- a/src/trinterp/AtnDotWriter.cs
+++ b/src/trinterp/AtnDotWriter.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Text;
 
 namespace trinterp;
@@ -15,7 +16,8 @@ public static class AtnDotWriter
     // ---- public entry points ------------------------------------------------
 
     /// <summary>Writes one &lt;ruleName&gt;.dot per rule to outDir.</summary>
-    public static void WritePerRule(GrammarModel grammar, ATN atn, string outDir)
+    public static void WritePerRule(GrammarModel grammar, ATN atn, string outDir,
+                                    StateLocationMap lm)
     {
         var decisionNumbers    = BuildDecisionNumbers(atn);
         var leftRecursiveRules = FindLeftRecursiveRules(atn);
@@ -24,36 +26,44 @@ public static class AtnDotWriter
             var rule = grammar.Rules[i];
             var start = atn.ruleToStartState[i];
             var stop  = atn.ruleToStopState[i];
-            var dot   = RuleToDot(rule.Name, start, stop, grammar, decisionNumbers, leftRecursiveRules);
+            var dot   = RuleToDot(rule.Name, start, stop, grammar, decisionNumbers, leftRecursiveRules, lm);
             var path  = Path.Combine(outDir, grammar.Name + "." + rule.Name + ".dot");
             File.WriteAllText(path, dot);
         }
     }
 
     /// <summary>Writes a single &lt;grammarName&gt;.atn.dot with every rule's states combined.</summary>
-    public static void WriteCombined(GrammarModel grammar, ATN atn, string outDir)
+    public static void WriteCombined(GrammarModel grammar, ATN atn, string outDir,
+                                     StateLocationMap lm)
     {
-        var dot  = CombinedToDot(grammar, atn);
+        var dot  = CombinedToDot(grammar, atn, lm);
         var path = Path.Combine(outDir, grammar.Name + ".atn.dot");
         File.WriteAllText(path, dot);
     }
 
     /// <summary>
     /// Writes a tab-separated state map to &lt;grammarName&gt;.state-map.tsv.
-    /// Each row: stateNumber TAB ruleName TAB line TAB col
-    /// Line/col are -1 when trparse was not invoked with -l.
+    /// Each row: stateNumber TAB ruleName TAB locations
+    /// where locations is a semicolon-separated list of "line:col" pairs (1-based line,
+    /// 0-based col), or "-" when no source location is available.
+    /// Requires trparse -l to have been used; otherwise all locations will be "-".
     /// </summary>
-    public static void WriteStateMap(GrammarModel grammar, ATN atn, string outDir)
+    public static void WriteStateMap(GrammarModel grammar, ATN atn, string outDir,
+                                     StateLocationMap lm)
     {
         var sb = new System.Text.StringBuilder();
-        sb.AppendLine("state\trule\tline\tcol");
+        sb.AppendLine("state\trule\tlocations");
         foreach (var s in atn.states)
         {
             if (s == null) continue;
             string ruleName = s.ruleIndex >= 0 && s.ruleIndex < grammar.Rules.Count
                 ? grammar.Rules[s.ruleIndex].Name
                 : "(none)";
-            sb.AppendLine($"{s.stateNumber}\t{ruleName}\t{s.SourceLine}\t{s.SourceColumn}");
+            var locs = lm[s.stateNumber];
+            string locsStr = locs.Count == 0
+                ? "-"
+                : string.Join(";", Sorted(locs).Select(l => $"{l.Line}:{l.Col}"));
+            sb.AppendLine($"{s.stateNumber}\t{ruleName}\t{locsStr}");
         }
         var path = Path.Combine(outDir, grammar.Name + ".state-map.tsv");
         File.WriteAllText(path, sb.ToString());
@@ -63,7 +73,7 @@ public static class AtnDotWriter
 
     private static string RuleToDot(string ruleName, RuleStartState start, RuleStopState stop,
                                     GrammarModel grammar, Dictionary<DecisionState, int> decisionNumbers,
-                                    HashSet<int> leftRecursiveRules)
+                                    HashSet<int> leftRecursiveRules, StateLocationMap lm)
     {
         // Collect states reachable from the rule start, scoped to this rule:
         //  - For RuleTransitions follow followState (skip called-rule interior)
@@ -89,7 +99,7 @@ public static class AtnDotWriter
         var sb = new StringBuilder();
         sb.AppendLine("digraph ATN {");
         sb.AppendLine("rankdir=LR;");
-        AppendNodes(sb, Sorted(states), decisionNumbers);
+        AppendNodes(sb, Sorted(states), decisionNumbers, lm);
         AppendEdges(sb, Sorted(states), states, grammar, decisionNumbers, ruleTransitionToFollow: true, leftRecursiveRules);
         sb.AppendLine("}");
         return sb.ToString();
@@ -97,7 +107,7 @@ public static class AtnDotWriter
 
     // ---- combined digraph ---------------------------------------------------
 
-    private static string CombinedToDot(GrammarModel grammar, ATN atn)
+    private static string CombinedToDot(GrammarModel grammar, ATN atn, StateLocationMap lm)
     {
         var decisionNumbers    = BuildDecisionNumbers(atn);
         var leftRecursiveRules = FindLeftRecursiveRules(atn);
@@ -111,7 +121,7 @@ public static class AtnDotWriter
         allStates.Sort((a, b) => a.stateNumber.CompareTo(b.stateNumber));
         var allSet = new HashSet<ATNState>(allStates);
 
-        AppendNodes(sb, allStates, decisionNumbers);
+        AppendNodes(sb, allStates, decisionNumbers, lm);
         // In the combined view show the actual RuleTransition target (rule start),
         // not the followState — the return arc is already an epsilon from the stop state.
         AppendEdges(sb, allStates, allSet, grammar, decisionNumbers, ruleTransitionToFollow: false, leftRecursiveRules);
@@ -122,12 +132,13 @@ public static class AtnDotWriter
     // ---- shared node / edge rendering --------------------------------------
 
     private static void AppendNodes(StringBuilder sb, IEnumerable<ATNState> states,
-                                    Dictionary<DecisionState, int> decisionNumbers)
+                                    Dictionary<DecisionState, int> decisionNumbers,
+                                    StateLocationMap lm)
     {
         foreach (var s in states)
         {
             string nodeId  = $"s{s.stateNumber}";
-            string tooltip = StateTooltip(s);
+            string tooltip = StateTooltip(s, lm);
             // StarBlockStartState and PlusBlockStartState are always circles even when
             // they appear in decisionToState (multi-alt case); check them before the
             // generic DecisionState branch below.
@@ -207,13 +218,16 @@ public static class AtnDotWriter
     }
 
     /// <summary>
-    /// Returns a DOT tooltip attribute string for <paramref name="s"/> when source location
-    /// is available, e.g. <c>, tooltip="line 5, col 3"</c>. Returns empty string otherwise.
+    /// Returns a DOT tooltip attribute string for <paramref name="s"/> using its set of
+    /// source locations from <paramref name="lm"/>, e.g.
+    /// <c>, tooltip="line 5, col 3; line 6, col 10"</c>. Returns empty string when none.
     /// </summary>
-    private static string StateTooltip(ATNState s)
+    private static string StateTooltip(ATNState s, StateLocationMap lm)
     {
-        if (s.SourceLine < 0) return string.Empty;
-        return $", tooltip=\"line {s.SourceLine}, col {s.SourceColumn}\"";
+        var locs = lm[s.stateNumber];
+        if (locs.Count == 0) return string.Empty;
+        var text = string.Join("; ", Sorted(locs).Select(l => $"line {l.Line}, col {l.Col}"));
+        return $", tooltip=\"{text}\"";
     }
 
     private static void AppendEdges(StringBuilder sb, IEnumerable<ATNState> states,
@@ -274,6 +288,9 @@ public static class AtnDotWriter
         list.Sort((a, b) => a.stateNumber.CompareTo(b.stateNumber));
         return list;
     }
+
+    private static IEnumerable<StateLocationMap.SourceLoc> Sorted(IReadOnlySet<StateLocationMap.SourceLoc> locs)
+        => locs.OrderBy(l => l.Line).ThenBy(l => l.Col);
 
     private static Dictionary<DecisionState, int> BuildDecisionNumbers(ATN atn)
     {

--- a/src/trinterp/AtnDotWriter.cs
+++ b/src/trinterp/AtnDotWriter.cs
@@ -46,7 +46,7 @@ public static class AtnDotWriter
     /// Each row: stateNumber TAB ruleName TAB locations
     /// where locations is a semicolon-separated list of "line:col" pairs (1-based line,
     /// 0-based col), or "-" when no source location is available.
-    /// Requires trparse -l to have been used; otherwise all locations will be "-".
+    /// Requires <c>dotnet trash parse -l</c> to have been used; otherwise all locations will be "-".
     /// </summary>
     public static string FormatStateMap(GrammarModel grammar, ATN atn, StateLocationMap lm)
     {

--- a/src/trinterp/Command.cs
+++ b/src/trinterp/Command.cs
@@ -123,6 +123,11 @@ public class Command
             return;
         }
 
+        // ---- Build location map (needed for --state-map, --atn, --atn-combined) ----
+        StateLocationMap lm = (config.Atn || config.AtnCombined || config.StateMap)
+            ? StateLocationMap.Build(atn)
+            : null;
+
         // ---- Format content ----
         string interpContent;
         string tokensContent;
@@ -137,6 +142,9 @@ public class Command
             return;
         }
 
+        if (config.StateMap)
+            interpContent += AtnDotWriter.FormatStateMap(grammar, atn, lm);
+
         // ---- Write files ----
         var baseName = grammar.Name;
         var interpPath = Path.Combine(outDir, baseName + ".interp");
@@ -145,16 +153,10 @@ public class Command
         File.WriteAllText(interpPath, interpContent);
         File.WriteAllText(tokensPath, tokensContent);
 
-        StateLocationMap lm = (config.Atn || config.AtnCombined || config.StateMap)
-            ? StateLocationMap.Build(atn)
-            : null;
-
         if (config.Atn)
             AtnDotWriter.WritePerRule(grammar, atn, outDir, lm);
         if (config.AtnCombined)
             AtnDotWriter.WriteCombined(grammar, atn, outDir, lm);
-        if (config.StateMap)
-            AtnDotWriter.WriteStateMap(grammar, atn, outDir, lm);
 
         if (config.Verbose)
         {
@@ -165,8 +167,6 @@ public class Command
                     Console.Error.WriteLine($"[trinterp] Wrote {Path.Combine(outDir, rule.Name + ".dot")}");
             if (config.AtnCombined)
                 Console.Error.WriteLine($"[trinterp] Wrote {Path.Combine(outDir, grammar.Name + ".atn.dot")}");
-            if (config.StateMap)
-                Console.Error.WriteLine($"[trinterp] Wrote {Path.Combine(outDir, grammar.Name + ".state-map.tsv")}");
         }
     }
 }

--- a/src/trinterp/Command.cs
+++ b/src/trinterp/Command.cs
@@ -149,6 +149,8 @@ public class Command
             AtnDotWriter.WritePerRule(grammar, atn, outDir);
         if (config.AtnCombined)
             AtnDotWriter.WriteCombined(grammar, atn, outDir);
+        if (config.StateMap)
+            AtnDotWriter.WriteStateMap(grammar, atn, outDir);
 
         if (config.Verbose)
         {
@@ -159,6 +161,8 @@ public class Command
                     Console.Error.WriteLine($"[trinterp] Wrote {Path.Combine(outDir, rule.Name + ".dot")}");
             if (config.AtnCombined)
                 Console.Error.WriteLine($"[trinterp] Wrote {Path.Combine(outDir, grammar.Name + ".atn.dot")}");
+            if (config.StateMap)
+                Console.Error.WriteLine($"[trinterp] Wrote {Path.Combine(outDir, grammar.Name + ".state-map.tsv")}");
         }
     }
 }

--- a/src/trinterp/Command.cs
+++ b/src/trinterp/Command.cs
@@ -15,7 +15,7 @@ public class Command
 {
     public string Help() =>
         "trinterp: Generate .interp and .tokens files from an ANTLRv4 grammar parse tree.\n" +
-        "Usage: trparse grammar.g4 | trinterp [options]\n";
+        "Usage: dotnet trash parse grammar.g4 | dotnet trash interp [options]\n";
 
     public void Execute(Config config)
     {

--- a/src/trinterp/Command.cs
+++ b/src/trinterp/Command.cs
@@ -145,12 +145,16 @@ public class Command
         File.WriteAllText(interpPath, interpContent);
         File.WriteAllText(tokensPath, tokensContent);
 
+        StateLocationMap lm = (config.Atn || config.AtnCombined || config.StateMap)
+            ? StateLocationMap.Build(atn)
+            : null;
+
         if (config.Atn)
-            AtnDotWriter.WritePerRule(grammar, atn, outDir);
+            AtnDotWriter.WritePerRule(grammar, atn, outDir, lm);
         if (config.AtnCombined)
-            AtnDotWriter.WriteCombined(grammar, atn, outDir);
+            AtnDotWriter.WriteCombined(grammar, atn, outDir, lm);
         if (config.StateMap)
-            AtnDotWriter.WriteStateMap(grammar, atn, outDir);
+            AtnDotWriter.WriteStateMap(grammar, atn, outDir, lm);
 
         if (config.Verbose)
         {

--- a/src/trinterp/Config.cs
+++ b/src/trinterp/Config.cs
@@ -20,6 +20,9 @@ public class Config
     [Option("atn-combined", Required = false, HelpText = "Write a single Graphviz .dot file (<grammarName>.atn.dot) containing all rules.")]
     public bool AtnCombined { get; set; }
 
+    [Option("state-map", Required = false, HelpText = "Write a TSV file (<grammarName>.state-map.tsv) mapping each ATN state number to its rule and .g4 line/column. Requires trparse -l.")]
+    public bool StateMap { get; set; }
+
     [Option("optimize", Separator = ',', Required = false,
         HelpText = "Comma-separated ATN optimizations to apply: tail-epsilon, merge-sets, none. Default: tail-epsilon,merge-sets.")]
     public IEnumerable<string> Optimize { get; set; } = new[] { "tail-epsilon", "merge-sets" };

--- a/src/trinterp/Config.cs
+++ b/src/trinterp/Config.cs
@@ -20,7 +20,7 @@ public class Config
     [Option("atn-combined", Required = false, HelpText = "Write a single Graphviz .dot file (<grammarName>.atn.dot) containing all rules.")]
     public bool AtnCombined { get; set; }
 
-    [Option("state-map", Required = false, HelpText = "Write a TSV file (<grammarName>.state-map.tsv) mapping each ATN state number to its rule and .g4 line/column. Requires trparse -l.")]
+    [Option("state-map", Required = false, HelpText = "Append a state-map section to the .interp file mapping each ATN state number to its rule and .g4 line/column. Requires dotnet trash parse -l.")]
     public bool StateMap { get; set; }
 
     [Option("optimize", Separator = ',', Required = false,

--- a/src/trinterp/GrammarModel.cs
+++ b/src/trinterp/GrammarModel.cs
@@ -15,6 +15,10 @@ public class RuleModel
     public string ModeName;     // lexer only: which mode the rule lives in
     public UnvParseTreeElement BodyNode; // parse tree node of the rule body
     public string ImplicitLiteral; // for T__N rules created from string literals in combined grammars
+    /// <summary>1-based line of the rule name token in the .g4 source, or -1 if unavailable.</summary>
+    public int SourceLine = -1;
+    /// <summary>0-based column of the rule name token in the .g4 source, or -1 if unavailable.</summary>
+    public int SourceColumn = -1;
     // Per-rule caseInsensitive option: null = inherit from grammar, true/false = explicit override.
     public bool? PerRuleCaseInsensitive;
     // True when the rule has a per-rule optionsSpec (affects StringLiteralToType aliasing).

--- a/src/trinterp/GrammarParser.cs
+++ b/src/trinterp/GrammarParser.cs
@@ -177,7 +177,9 @@ public class GrammarParser
             IsFragment = false,
             TokenType = 0,
             ModeName = modeName,
-            BodyNode = ruleBlock
+            BodyNode = ruleBlock,
+            SourceLine = SafeGetLine(nameNode),
+            SourceColumn = SafeGetColumn(nameNode),
         };
 
         // Collect rule-level named actions (@init, @after)
@@ -234,6 +236,8 @@ public class GrammarParser
             BodyNode = lexerRuleBlock,
             PerRuleCaseInsensitive = perRuleCaseInsensitive,
             HasRuleOptions = hasRuleOptions,
+            SourceLine = SafeGetLine(nameNode),
+            SourceColumn = SafeGetColumn(nameNode),
         };
         model.Rules.Add(rule);
     }
@@ -551,4 +555,43 @@ public class GrammarParser
     /// <summary>Returns the first terminal child with the given token-type name.</summary>
     public static UnvParseTreeElement ChildTerminal(UnvParseTreeElement node, string tokenTypeName) =>
         node?.Children.FirstOrDefault(c => c.IsTerminal() && c.LocalName == tokenTypeName);
+
+    /// <summary>
+    /// Returns the 1-based line of a terminal node, or -1 if line information was not
+    /// included in the parse (i.e. trparse was not invoked with -l / --line).
+    /// </summary>
+    public static int SafeGetLine(UnvParseTreeElement node)
+    {
+        if (node == null) return -1;
+        try { return node.GetLine(); }
+        catch { return -1; }
+    }
+
+    /// <summary>
+    /// Returns the 0-based column of a terminal node, or -1 if column information was
+    /// not included in the parse.
+    /// </summary>
+    public static int SafeGetColumn(UnvParseTreeElement node)
+    {
+        if (node == null) return -1;
+        try { return node.GetColumn(); }
+        catch { return -1; }
+    }
+
+    /// <summary>
+    /// Returns the source location (line, column) of the first token reachable from
+    /// <paramref name="node"/>. Works for both terminal and non-terminal elements.
+    /// Returns (-1, -1) when line information was not included in the parse.
+    /// </summary>
+    public static (int line, int col) SourceOf(UnvParseTreeElement node)
+    {
+        if (node == null) return (-1, -1);
+        if (node.IsTerminal()) return (SafeGetLine(node), SafeGetColumn(node));
+        foreach (var child in Children(node))
+        {
+            var loc = SourceOf(child);
+            if (loc.line != -1) return loc;
+        }
+        return (-1, -1);
+    }
 }

--- a/src/trinterp/GrammarParser.cs
+++ b/src/trinterp/GrammarParser.cs
@@ -558,7 +558,7 @@ public class GrammarParser
 
     /// <summary>
     /// Returns the 1-based line of a terminal node, or -1 if line information was not
-    /// included in the parse (i.e. trparse was not invoked with -l / --line).
+    /// included in the parse (i.e. <c>dotnet trash parse</c> was not invoked with -l / --line).
     /// </summary>
     public static int SafeGetLine(UnvParseTreeElement node)
     {

--- a/src/trinterp/LexerAtnFactory.cs
+++ b/src/trinterp/LexerAtnFactory.cs
@@ -316,12 +316,14 @@ public class LexerAtnFactory : ParserAtnFactory
         if (tokenRef != null)
         {
             var name = GetText(tokenRef).Trim();
+            SetSrcRange(tokenRef, name.Length);
             return MakeLexerTokenRef(name);
         }
         var strLit = ChildTerminal(terminalDef, "STRING_LITERAL");
         if (strLit != null)
         {
             var lit = GetText(strLit).Trim();
+            SetSrcRange(strLit, lit.Length);
             return MakeCharSequence(lit);
         }
         return MakeEpsilonHandle();
@@ -362,8 +364,11 @@ public class LexerAtnFactory : ParserAtnFactory
         if (literals.Count < 2) return MakeEpsilonHandle();
 
         var fromChar = CharValue(GetText(literals[0]).Trim());
-        var toChar = CharValue(GetText(literals[1]).Trim());
+        var toChar   = CharValue(GetText(literals[1]).Trim());
         if (fromChar < 0 || toChar < 0) return MakeEpsilonHandle();
+
+        var endLit = GetText(literals[1]).Trim();
+        SetSrcRange(literals[0], literals[1], endLit.Length);
 
         var set = new IntervalSet();
         set.Add(fromChar, toChar);

--- a/src/trinterp/ParserAtnFactory.cs
+++ b/src/trinterp/ParserAtnFactory.cs
@@ -26,9 +26,14 @@ public class ParserAtnFactory
     protected int _nextPredIndex;
 
     // Source location of the grammar construct currently being translated into states.
-    // Set by SetSrc() before any NewState<T>() call; propagated into each state's fields.
-    private int _srcLine = -1;
-    private int _srcCol  = -1;
+    // Set by SetSrc() / SetSrcRange() before any NewState<T>() call.
+    // _srcLine/_srcCol    = start of the grammar element (stamped on every new state).
+    // _srcEndLine/_srcEndCol = exclusive end of the grammar element (stamped only on match
+    //                          states; -1 for structural states like block-starts/-ends).
+    private int _srcLine    = -1;
+    private int _srcCol     = -1;
+    private int _srcEndLine = -1;
+    private int _srcEndCol  = -1;
 
 
     public ParserAtnFactory(GrammarModel grammar, OptimizeOptions optimize = null)
@@ -633,12 +638,14 @@ public class ParserAtnFactory
         if (tokenRef != null)
         {
             var name = GetText(tokenRef).Trim();
+            SetSrcRange(tokenRef, name.Length);
             return MakeTokenRef(name);
         }
         var strLit = ChildTerminal(terminalDef, "STRING_LITERAL");
         if (strLit != null)
         {
             var lit = GetText(strLit).Trim();
+            SetSrcRange(strLit, lit.Length);
             return MakeStringLiteral(lit);
         }
         return MakeEpsilonHandle();
@@ -650,6 +657,7 @@ public class ParserAtnFactory
         var nameNode = ChildTerminal(ruleref, "RULE_REF");
         if (nameNode == null) return null;
         var name = GetText(nameNode).Trim();
+        SetSrcRange(nameNode, name.Length);
         return MakeRuleRef(name);
     }
 
@@ -1100,9 +1108,11 @@ public class ParserAtnFactory
     protected T NewState<T>() where T : ATNState, new()
     {
         var s = new T();
-        s.ruleIndex    = _currentRule?.Index ?? -1;
-        s.SourceLine   = _srcLine;
-        s.SourceColumn = _srcCol;
+        s.ruleIndex       = _currentRule?.Index ?? -1;
+        s.SourceLine      = _srcLine;
+        s.SourceColumn    = _srcCol;
+        s.SourceEndLine   = _srcEndLine;
+        s.SourceEndColumn = _srcEndCol;
         _atn.AddState(s);
         return s;
     }
@@ -1110,29 +1120,72 @@ public class ParserAtnFactory
     protected T NewState<T>(RuleModel rule) where T : ATNState, new()
     {
         var s = new T();
-        s.ruleIndex    = rule?.Index ?? -1;
-        s.SourceLine   = _srcLine;
-        s.SourceColumn = _srcCol;
+        s.ruleIndex       = rule?.Index ?? -1;
+        s.SourceLine      = _srcLine;
+        s.SourceColumn    = _srcCol;
+        s.SourceEndLine   = _srcEndLine;
+        s.SourceEndColumn = _srcEndCol;
         _atn.AddState(s);
         return s;
     }
 
     /// <summary>
-    /// Set the source location context that will be stamped onto the next NewState call(s).
-    /// Pass explicit line/column (e.g. from a RuleModel).
+    /// Set the source location context (start only) that will be stamped onto the next NewState call(s).
+    /// Clears any previously set end location.
     /// </summary>
-    protected void SetSrc(int line, int col) { _srcLine = line; _srcCol = col; }
+    protected void SetSrc(int line, int col)
+    {
+        _srcLine    = line;
+        _srcCol     = col;
+        _srcEndLine = -1;
+        _srcEndCol  = -1;
+    }
 
     /// <summary>
     /// Set the source location context from a parse-tree node.
-    /// Walks into the first reachable terminal if <paramref name="node"/> is a non-terminal,
-    /// so it is safe to call with either a token or a rule-node.
+    /// Walks into the first reachable terminal if <paramref name="node"/> is a non-terminal.
+    /// Clears any previously set end location.
     /// </summary>
     protected void SetSrc(UnvParseTreeElement node)
     {
         var (line, col) = SourceOf(node);
-        _srcLine = line;
-        _srcCol  = col;
+        _srcLine    = line;
+        _srcCol     = col;
+        _srcEndLine = -1;
+        _srcEndCol  = -1;
+    }
+
+    /// <summary>
+    /// Set both start and exclusive-end source location from a terminal token node.
+    /// Call this instead of <see cref="SetSrc(UnvParseTreeElement)"/> when creating "match" states
+    /// so that <see cref="StateLocationMap"/> can compute post-transition locations for the
+    /// successor state via <c>DirectPostLocs</c>.
+    /// </summary>
+    protected void SetSrcRange(UnvParseTreeElement terminal, int textLength)
+    {
+        var line    = SafeGetLine(terminal);
+        var col     = SafeGetColumn(terminal);
+        _srcLine    = line;
+        _srcCol     = col;
+        _srcEndLine = line >= 0 ? line : -1;
+        _srcEndCol  = col >= 0 ? col + textLength : -1;
+    }
+
+    /// <summary>
+    /// Set start location from <paramref name="startTerminal"/> and exclusive-end location
+    /// from the end of <paramref name="endTerminal"/> (its column + <paramref name="endTextLength"/>).
+    /// Use for multi-token grammar elements like character ranges (<c>'a'..'z'</c>).
+    /// </summary>
+    protected void SetSrcRange(UnvParseTreeElement startTerminal, UnvParseTreeElement endTerminal, int endTextLength)
+    {
+        var startLine = SafeGetLine(startTerminal);
+        var startCol  = SafeGetColumn(startTerminal);
+        var endLine   = SafeGetLine(endTerminal);
+        var endCol    = SafeGetColumn(endTerminal);
+        _srcLine    = startLine;
+        _srcCol     = startCol;
+        _srcEndLine = endLine >= 0 ? endLine : -1;
+        _srcEndCol  = endCol >= 0 ? endCol + endTextLength : -1;
     }
 
     protected void AddEpsilon(ATNState from, ATNState to, bool prepend = false)

--- a/src/trinterp/ParserAtnFactory.cs
+++ b/src/trinterp/ParserAtnFactory.cs
@@ -713,6 +713,32 @@ public class ParserAtnFactory
     {
         if (alts.Count == 0) return MakeEpsilonHandle();
 
+        // Restore block source position before creating any structural states.
+        // Walking the alternatives (via WalkBlock) overwrites _srcLine/_srcCol with the
+        // position of the last grammar element inside the block.  We need all block-level
+        // states (the collapsed set state, the BasicBlockStartState, BlockEndState) to be
+        // stamped with the block's own start position, not the last alt's position.
+        //
+        // For suffixed blocks (?, *, +) we also record the exclusive end of the suffix token
+        // as SourceEndLine/SourceEndColumn.  For optional (?) blocks this end position is
+        // used by StateLocationMap to attribute the "skip" location to the decision state.
+        if (blkCtx != null)
+        {
+            var (blockLine, blockCol) = SourceOf(blkCtx);
+            if (ebnfSuffix != null && blockLine >= 0)
+            {
+                var (sfxLine, sfxCol) = SourceOf(ebnfSuffix);
+                var sfxText           = GetText(ebnfSuffix).Trim();
+                SetSrcRange(blockLine, blockCol,
+                            sfxLine >= 0 ? sfxLine : -1,
+                            sfxCol  >= 0 ? sfxCol + sfxText.Length : -1);
+            }
+            else
+            {
+                SetSrc(blockLine, blockCol);
+            }
+        }
+
         // antlr4's BlockSetTransformer pre-processes the grammar AST to collapse
         // blocks where every alternative is a single atom/range/set into one SET
         // transition. Implement the equivalent here at construction time so we
@@ -1169,6 +1195,18 @@ public class ParserAtnFactory
         _srcCol     = col;
         _srcEndLine = line >= 0 ? line : -1;
         _srcEndCol  = col >= 0 ? col + textLength : -1;
+    }
+
+    /// <summary>
+    /// Set source location directly with explicit start and exclusive-end coordinates.
+    /// Use when the positions are already known (e.g. computed from a block node + its suffix).
+    /// </summary>
+    protected void SetSrcRange(int startLine, int startCol, int endLine, int endCol)
+    {
+        _srcLine    = startLine;
+        _srcCol     = startCol;
+        _srcEndLine = endLine;
+        _srcEndCol  = endCol;
     }
 
     /// <summary>

--- a/src/trinterp/ParserAtnFactory.cs
+++ b/src/trinterp/ParserAtnFactory.cs
@@ -25,6 +25,11 @@ public class ParserAtnFactory
     // Global sempred counter (incremented as predicates are encountered).
     protected int _nextPredIndex;
 
+    // Source location of the grammar construct currently being translated into states.
+    // Set by SetSrc() before any NewState<T>() call; propagated into each state's fields.
+    private int _srcLine = -1;
+    private int _srcCol  = -1;
+
 
     public ParserAtnFactory(GrammarModel grammar, OptimizeOptions optimize = null)
     {
@@ -62,6 +67,7 @@ public class ParserAtnFactory
         _atn.ruleToStopState = new RuleStopState[n];
         foreach (var rule in _grammar.Rules)
         {
+            SetSrc(rule.SourceLine, rule.SourceColumn);
             var start = NewState<RuleStartState>(rule);
             var stop = NewState<RuleStopState>(rule);
             start.stopState = stop;
@@ -482,6 +488,7 @@ public class ParserAtnFactory
     protected AtnHandle WalkAlternative(UnvParseTreeElement altNode)
     {
         // alternative : elementOptions? element+  |  (empty)
+        SetSrc(altNode);
         var elements = new List<AtnHandle>();
         foreach (var child in Children(altNode))
         {
@@ -502,6 +509,7 @@ public class ParserAtnFactory
         //         | atom (ebnfSuffix |)
         //         | ebnf
         //         | actionBlock QUESTION? predicateOptions?
+        SetSrc(element);
 
         var actionBlock = Child(element, "actionBlock");
         if (actionBlock != null)
@@ -581,6 +589,7 @@ public class ParserAtnFactory
     protected AtnHandle WalkBlock(UnvParseTreeElement blockNode, UnvParseTreeElement ebnfSuffix)
     {
         // block : LPAREN (optionsSpec? ruleAction* COLON)? altList RPAREN
+        SetSrc(blockNode);
         var altList = Child(blockNode, "altList");
         if (altList == null) return MakeEpsilonHandle();
 
@@ -1091,7 +1100,9 @@ public class ParserAtnFactory
     protected T NewState<T>() where T : ATNState, new()
     {
         var s = new T();
-        s.ruleIndex = _currentRule?.Index ?? -1;
+        s.ruleIndex    = _currentRule?.Index ?? -1;
+        s.SourceLine   = _srcLine;
+        s.SourceColumn = _srcCol;
         _atn.AddState(s);
         return s;
     }
@@ -1099,9 +1110,29 @@ public class ParserAtnFactory
     protected T NewState<T>(RuleModel rule) where T : ATNState, new()
     {
         var s = new T();
-        s.ruleIndex = rule?.Index ?? -1;
+        s.ruleIndex    = rule?.Index ?? -1;
+        s.SourceLine   = _srcLine;
+        s.SourceColumn = _srcCol;
         _atn.AddState(s);
         return s;
+    }
+
+    /// <summary>
+    /// Set the source location context that will be stamped onto the next NewState call(s).
+    /// Pass explicit line/column (e.g. from a RuleModel).
+    /// </summary>
+    protected void SetSrc(int line, int col) { _srcLine = line; _srcCol = col; }
+
+    /// <summary>
+    /// Set the source location context from a parse-tree node.
+    /// Walks into the first reachable terminal if <paramref name="node"/> is a non-terminal,
+    /// so it is safe to call with either a token or a rule-node.
+    /// </summary>
+    protected void SetSrc(UnvParseTreeElement node)
+    {
+        var (line, col) = SourceOf(node);
+        _srcLine = line;
+        _srcCol  = col;
     }
 
     protected void AddEpsilon(ATNState from, ATNState to, bool prepend = false)

--- a/src/trinterp/StateLocationMap.cs
+++ b/src/trinterp/StateLocationMap.cs
@@ -1,0 +1,207 @@
+using System.Collections.Generic;
+
+namespace trinterp;
+
+/// <summary>
+/// Maps each ATN state number to the set of (line, col) pairs in the .g4 source
+/// that it corresponds to.
+///
+/// Formal definition
+/// -----------------
+///   DirectPreLocs(s)  = { (s.SourceLine, s.SourceColumn) |
+///                          s has ≥1 outgoing non-epsilon transition ∧ s.SourceLine ≥ 0 }
+///
+///   DirectPostLocs(u) = { (t.SourceEndLine, t.SourceEndColumn) |
+///                          ∃ non-eps transition t→u ∧ t.SourceEndLine ≥ 0 }
+///
+///   fwd(s) = states reachable from s via ≥0 epsilon transitions (forward epsilon closure)
+///   bwd(s) = states from which s is reachable via ≥0 epsilon transitions (backward epsilon closure)
+///
+///   Locs(s) = ⋃{ DirectPreLocs(t)  | t ∈ fwd(s) }
+///           ∪ ⋃{ DirectPostLocs(t) | t ∈ bwd(s) }
+///
+/// Intuition
+/// ---------
+///   • A decision/entry state (s26, s124) maps to the start positions of all match
+///     states reachable from it via epsilon transitions.
+///   • A post-match merge state (s125 BlockEnd, s27 RuleStop) maps to the exclusive-end
+///     positions of all grammar elements that epsilon-transition into it.
+/// </summary>
+public sealed class StateLocationMap
+{
+    /// <summary>An (line, col) pair in .g4 source (1-based line, 0-based col).</summary>
+    public readonly record struct SourceLoc(int Line, int Col);
+
+    // stateNumber → set of source locations
+    private readonly Dictionary<int, HashSet<SourceLoc>> _map = new();
+
+    private StateLocationMap() { }
+
+    /// <summary>Build the map for the given ATN.</summary>
+    public static StateLocationMap Build(ATN atn)
+    {
+        var m = new StateLocationMap();
+        m.Compute(atn);
+        return m;
+    }
+
+    /// <summary>
+    /// Returns the set of source locations for <paramref name="stateNumber"/>,
+    /// or an empty set if none.
+    /// </summary>
+    public IReadOnlySet<SourceLoc> this[int stateNumber] =>
+        _map.TryGetValue(stateNumber, out var s) ? s : _empty;
+
+    private static readonly HashSet<SourceLoc> _empty = new();
+
+    // =========================================================================
+
+    private void Compute(ATN atn)
+    {
+        var states = atn.states;
+
+        // Step 1: Collect epsilon and non-epsilon edges.
+        //
+        // For each state with ≥1 non-epsilon outgoing transition:
+        //   directPre[s] = { (s.SourceLine, s.SourceColumn) }  (if SourceLine ≥ 0)
+        //
+        // For each state u that is the target of a non-epsilon transition from t:
+        //   directPost[u] += { (t.SourceEndLine, t.SourceEndColumn) }  (if SourceEndLine ≥ 0)
+        //
+        // epsEdges: list of (from, to) for epsilon transitions (used for closure BFS)
+
+        var directPre  = new Dictionary<int, HashSet<SourceLoc>>();
+        var directPost = new Dictionary<int, HashSet<SourceLoc>>();
+        var epsEdgesFrom = new Dictionary<int, List<int>>(); // from → list of to
+        var epsEdgesTo   = new Dictionary<int, List<int>>(); // to → list of from (reverse)
+
+        foreach (var s in states)
+        {
+            if (s == null) continue;
+            bool hasNonEps = false;
+            for (int i = 0; i < s.NumberOfTransitions; i++)
+            {
+                var t = s.Transition(i);
+                if (t is EpsilonTransition)
+                {
+                    AddEdge(epsEdgesFrom, s.stateNumber, t.target.stateNumber);
+                    AddEdge(epsEdgesTo,   t.target.stateNumber, s.stateNumber);
+                }
+                else
+                {
+                    hasNonEps = true;
+                    // directPost for the post-transition state.
+                    // For RuleTransition the logical "return" state is followState, not target
+                    // (target is the called rule's start state, which is far away).
+                    var postState = t is RuleTransition rt ? rt.followState : t.target;
+                    if (s.SourceEndLine >= 0)
+                    {
+                        var loc = new SourceLoc(s.SourceEndLine, s.SourceEndColumn);
+                        AddLoc(directPost, postState.stateNumber, loc);
+                    }
+                }
+            }
+            if (hasNonEps && s.SourceLine >= 0)
+            {
+                AddLoc(directPre, s.stateNumber, new SourceLoc(s.SourceLine, s.SourceColumn));
+            }
+        }
+
+        // Step 2: Forward epsilon closure.
+        // fwdPre[s] = ⋃{ directPre[t] | t ∈ fwd(s) }
+        // We propagate directPre backwards through epsilon edges:
+        // if there is an eps edge s→t, then fwdPre[s] ⊇ fwdPre[t].
+        // This is equivalent to computing fwd(s) for each s and unioning directPre.
+        // We do it efficiently via a reverse-topological BFS on the epsilon graph.
+
+        var fwdPre = new Dictionary<int, HashSet<SourceLoc>>();
+
+        // Seed with direct values
+        foreach (var (sn, locs) in directPre)
+            GetOrCreate(fwdPre, sn).UnionWith(locs);
+
+        // Propagate: for each eps edge from→to, fwdPre[from] gets fwdPre[to].
+        // We use a worklist: start with all states that have directPre, propagate
+        // backwards through eps edges until fixed point.
+        var worklist = new Queue<int>(directPre.Keys);
+        while (worklist.Count > 0)
+        {
+            var sn = worklist.Dequeue();
+            if (!fwdPre.TryGetValue(sn, out var locs) || locs.Count == 0) continue;
+            // Any state that has an eps edge to sn should also inherit locs.
+            if (!epsEdgesTo.TryGetValue(sn, out var preds)) continue;
+            foreach (var pred in preds)
+            {
+                var predSet = GetOrCreate(fwdPre, pred);
+                int before = predSet.Count;
+                predSet.UnionWith(locs);
+                if (predSet.Count != before)
+                    worklist.Enqueue(pred);
+            }
+        }
+
+        // Step 3: Backward epsilon closure.
+        // bwdPost[s] = ⋃{ directPost[t] | t ∈ bwd(s) }
+        // Propagate directPost forward through epsilon edges:
+        // if there is an eps edge from→to, then bwdPost[to] ⊇ bwdPost[from].
+
+        var bwdPost = new Dictionary<int, HashSet<SourceLoc>>();
+
+        foreach (var (sn, locs) in directPost)
+            GetOrCreate(bwdPost, sn).UnionWith(locs);
+
+        worklist = new Queue<int>(directPost.Keys);
+        while (worklist.Count > 0)
+        {
+            var sn = worklist.Dequeue();
+            if (!bwdPost.TryGetValue(sn, out var locs) || locs.Count == 0) continue;
+            if (!epsEdgesFrom.TryGetValue(sn, out var succs)) continue;
+            foreach (var succ in succs)
+            {
+                var succSet = GetOrCreate(bwdPost, succ);
+                int before = succSet.Count;
+                succSet.UnionWith(locs);
+                if (succSet.Count != before)
+                    worklist.Enqueue(succ);
+            }
+        }
+
+        // Step 4: Locs(s) = fwdPre[s] ∪ bwdPost[s]
+        var allKeys = new HashSet<int>();
+        foreach (var k in fwdPre.Keys)  allKeys.Add(k);
+        foreach (var k in bwdPost.Keys) allKeys.Add(k);
+
+        foreach (var sn in allKeys)
+        {
+            var combined = new HashSet<SourceLoc>();
+            if (fwdPre.TryGetValue(sn,  out var pre))  combined.UnionWith(pre);
+            if (bwdPost.TryGetValue(sn, out var post)) combined.UnionWith(post);
+            if (combined.Count > 0)
+                _map[sn] = combined;
+        }
+    }
+
+    // =========================================================================
+    // Helpers
+
+    private static void AddEdge(Dictionary<int, List<int>> dict, int key, int value)
+    {
+        if (!dict.TryGetValue(key, out var list))
+            dict[key] = list = new List<int>();
+        list.Add(value);
+    }
+
+    private static void AddLoc(Dictionary<int, HashSet<SourceLoc>> dict, int key, SourceLoc loc)
+    {
+        if (!dict.TryGetValue(key, out var set))
+            dict[key] = set = new HashSet<SourceLoc>();
+        set.Add(loc);
+    }
+
+    private static HashSet<SourceLoc> GetOrCreate(Dictionary<int, HashSet<SourceLoc>> dict, int key)
+    {
+        if (!dict.TryGetValue(key, out var set))
+            dict[key] = set = new HashSet<SourceLoc>();
+        return set;
+    }
+}

--- a/src/trinterp/StateLocationMap.cs
+++ b/src/trinterp/StateLocationMap.cs
@@ -97,8 +97,17 @@ public sealed class StateLocationMap
                 {
                     if (!isRuleStop)
                     {
+                        // The bypass epsilon of an optional block (BasicBlockStartState → its
+                        // endState) is used for forward bwdPost propagation but NOT for backward
+                        // fwdPre propagation.  Without this exclusion, positions of states that
+                        // follow the optional block (e.g. the next token) would leak backward
+                        // through the bypass into the decision state.
+                        bool isBypass = s is BasicBlockStartState bss
+                                        && t.target == bss.endState
+                                        && s.SourceEndLine >= 0; // only optional blocks
                         AddEdge(epsEdgesFrom, s.stateNumber, t.target.stateNumber);
-                        AddEdge(epsEdgesTo,   t.target.stateNumber, s.stateNumber);
+                        if (!isBypass)
+                            AddEdge(epsEdgesTo, t.target.stateNumber, s.stateNumber);
                     }
                 }
                 else
@@ -118,6 +127,21 @@ public sealed class StateLocationMap
             if (hasNonEps && s.SourceLine >= 0)
             {
                 AddLoc(directPre, s.stateNumber, new SourceLoc(s.SourceLine, s.SourceColumn));
+            }
+
+            // For optional block starts (BasicBlockStartState with SourceEndLine set by
+            // MakeBlock when ebnfSuffix = "?"):
+            //   • SourceLine/SourceColumn  = start of "(" — "about to try the block content"
+            //   • SourceEndLine/SourceEndColumn = exclusive end of "?" — "about to skip past
+            //     the entire optional block" (the position reached by the bypass epsilon)
+            // Both are meaningful "pre-positions" for this decision state and are seeded
+            // directly into directPre so that backward propagation distributes them to all
+            // eps-predecessors (e.g. the outer decision state).
+            if (s is BasicBlockStartState && s.SourceEndLine >= 0)
+            {
+                if (s.SourceLine >= 0)
+                    AddLoc(directPre, s.stateNumber, new SourceLoc(s.SourceLine, s.SourceColumn));
+                AddLoc(directPre, s.stateNumber, new SourceLoc(s.SourceEndLine, s.SourceEndColumn));
             }
         }
 

--- a/src/trinterp/StateLocationMap.cs
+++ b/src/trinterp/StateLocationMap.cs
@@ -68,7 +68,16 @@ public sealed class StateLocationMap
         // For each state u that is the target of a non-epsilon transition from t:
         //   directPost[u] += { (t.SourceEndLine, t.SourceEndColumn) }  (if SourceEndLine ≥ 0)
         //
-        // epsEdges: list of (from, to) for epsilon transitions (used for closure BFS)
+        // epsEdges: list of (from, to) for epsilon transitions (used for closure BFS).
+        //
+        // IMPORTANT: epsilon edges OUT of a RuleStopState are "rule-exit" links added by
+        // AddRuleFollowLinks. They connect the end of one rule to the caller's follow state,
+        // crossing a rule boundary. We deliberately exclude them from both propagation graphs
+        // so that:
+        //   • fwdPre backward propagation stays inside the rule (caller match-state positions
+        //     cannot leak back through the RuleStop into this rule's states), and
+        //   • bwdPost forward propagation stops at the RuleStop (end positions from inside the
+        //     rule cannot bleed into the caller's states via the RuleStop).
 
         var directPre  = new Dictionary<int, HashSet<SourceLoc>>();
         var directPost = new Dictionary<int, HashSet<SourceLoc>>();
@@ -79,13 +88,18 @@ public sealed class StateLocationMap
         {
             if (s == null) continue;
             bool hasNonEps = false;
+            // Epsilon edges from RuleStopState cross rule boundaries; exclude them.
+            bool isRuleStop = s is RuleStopState;
             for (int i = 0; i < s.NumberOfTransitions; i++)
             {
                 var t = s.Transition(i);
                 if (t is EpsilonTransition)
                 {
-                    AddEdge(epsEdgesFrom, s.stateNumber, t.target.stateNumber);
-                    AddEdge(epsEdgesTo,   t.target.stateNumber, s.stateNumber);
+                    if (!isRuleStop)
+                    {
+                        AddEdge(epsEdgesFrom, s.stateNumber, t.target.stateNumber);
+                        AddEdge(epsEdgesTo,   t.target.stateNumber, s.stateNumber);
+                    }
                 }
                 else
                 {

--- a/src/trinterp/readme.md
+++ b/src/trinterp/readme.md
@@ -6,7 +6,7 @@ Generate ANTLR4 `.interp` files from a grammar parse tree
 
 ## Description
 
-Reads an Antlr4 grammar parse tree from stdin (as produced by `trparse`) and
+Reads an Antlr4 grammar parse tree from stdin (as produced by `dotnet trash parse`) and
 writes `.interp` and `.tokens` files to the output directory. Supports both
 lexer and parser grammars, as well as combined grammars (which produce a lexer
 and parser `.interp` pair).
@@ -28,8 +28,8 @@ consume them without needing the generated target-language source.
 
 ## Examples
 
-    trparse CLexer.g4 CParser.g4 | trinterp -o out/
-    trparse Heavy.g4 | trinterp --actions-in-interp -o out/
+    dotnet trash parse CLexer.g4 CParser.g4 | dotnet trash interp -o out/
+    dotnet trash parse Heavy.g4 | dotnet trash interp --actions-in-interp -o out/
 
 ## Current version
 


### PR DESCRIPTION
Stamps each ATNState with SourceLine/SourceColumn (1-based line, 0-based column) from the grammar parse tree node that produced it. Requires `trparse -l` to include line/column in the input parse tree; gracefully degrades to -1 when that info is absent.

Changes:
- ATNState: add SourceLine/SourceColumn fields
- GrammarModel/RuleModel: add SourceLine/SourceColumn for rule-name token
- GrammarParser: record rule-name location in AddParserRule/AddLexerRule; add SafeGetLine, SafeGetColumn, SourceOf helpers
- ParserAtnFactory: track _srcLine/_srcCol context; SetSrc(node) and SetSrc(line,col) overloads; both NewState<T> overloads stamp location; SetSrc called in CreateRuleStartStopStates, WalkAlternative, WalkElement, WalkBlock
- AtnDotWriter: add tooltip="line L, col C" to every DOT node; new WriteStateMap() emits <Grammar>.state-map.tsv (state/rule/line/col)
- Config: add --state-map option
- Command: wire --state-map to AtnDotWriter.WriteStateMap

Usage:
  dotnet trash parse -l Grammar.g4 | trinterp --atn --state-map