### PR TITLE
Update copyright year to 2026

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 Ken Domino
+Copyright (c) 2021-2026 Ken Domino
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/VsIde/license.txt
+++ b/src/VsIde/license.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2017-2023 Ken Domino
+Copyright (c) 2017-2026 Ken Domino
 
 (MIT license)
 

--- a/src/grammars/antlr4/examples/grammars-v4/asm/ptx/ptx-isa-2.1/Ptx.g4
+++ b/src/grammars/antlr4/examples/grammars-v4/asm/ptx/ptx-isa-2.1/Ptx.g4
@@ -1,5 +1,5 @@
 /*
-   Copyright 2023 Ken Domino
+   Copyright 2026 Ken Domino
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/src/grammars/antlr4/examples/grammars-v4/dart2/Dart2Lexer.g4
+++ b/src/grammars/antlr4/examples/grammars-v4/dart2/Dart2Lexer.g4
@@ -1,6 +1,6 @@
 /* Generated Mon, Jun 13, 2022 8:11:58 AM EST
  *
- * Copyright (c) 2022, 2023 Ken Domino
+ * Copyright (c) 2022, 2026 Ken Domino
  * Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
  * for details. All rights reserved. Use of this source code is governed by a
  * BSD-style license that can be found in the LICENSE file.

--- a/src/grammars/antlr4/examples/grammars-v4/dart2/Dart2Parser.g4
+++ b/src/grammars/antlr4/examples/grammars-v4/dart2/Dart2Parser.g4
@@ -1,6 +1,6 @@
 /* Generated Mon, Jun 13, 2022 8:11:58 AM EST
  *
- * Copyright (c) 2022, 2023 Ken Domino
+ * Copyright (c) 2022, 2026 Ken Domino
  * Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
  * for details. All rights reserved. Use of this source code is governed by a
  * BSD-style license that can be found in the LICENSE file.

--- a/src/grammars/antlr4/examples/grammars-v4/spass/SpassLexer.g4
+++ b/src/grammars/antlr4/examples/grammars-v4/spass/SpassLexer.g4
@@ -1,6 +1,6 @@
 /* MIT License
 
-Copyright (c) 2022 Ken Domino
+Copyright (c) 2026 Ken Domino
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/grammars/antlr4/examples/grammars-v4/spass/SpassParser.g4
+++ b/src/grammars/antlr4/examples/grammars-v4/spass/SpassParser.g4
@@ -1,6 +1,6 @@
 /* MIT License
 
-Copyright (c) 2022 Ken Domino
+Copyright (c) 2026 Ken Domino
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/tragl/Program.cs
+++ b/src/tragl/Program.cs
@@ -36,7 +36,7 @@ public class Program
             {
                 h.AdditionalNewLineAfterOption = false;
                 h.Heading = "tragl";
-                h.Copyright = "Copyright (c) 2023 Ken Domino"; //change copyright text
+                h.Copyright = "Copyright (c) 2026 Ken Domino"; //change copyright text
                 h.AddPreOptionsText(new Command().Help());
                 return HelpText.DefaultParsingErrorsHandler(result, h);
             }, e => e);

--- a/src/tragl/readme.md
+++ b/src/tragl/readme.md
@@ -25,7 +25,7 @@ This tool is part of Trash, Transformations for Antlr Shell.
 
 The MIT License
 
-Copyright (c) 2025 Ken Domino
+Copyright (c) 2026 Ken Domino
 
 Permission is hereby granted, free of charge, 
 to any person obtaining a copy of this software and 

--- a/src/tranalyze/Program.cs
+++ b/src/tranalyze/Program.cs
@@ -35,7 +35,7 @@ public class Program
             {
                 h.AdditionalNewLineAfterOption = false;
                 h.Heading = "tranalyze";
-                h.Copyright = "Copyright (c) 2023 Ken Domino";
+                h.Copyright = "Copyright (c) 2026 Ken Domino";
                 h.AddPreOptionsText(new Command().Help());
                 return HelpText.DefaultParsingErrorsHandler(result, h);
             }, e => e);

--- a/src/tranalyze/readme.md
+++ b/src/tranalyze/readme.md
@@ -71,7 +71,7 @@ _Output_
 
 The MIT License
 
-Copyright (c) 2025 Ken Domino
+Copyright (c) 2026 Ken Domino
 
 Permission is hereby granted, free of charge, 
 to any person obtaining a copy of this software and 

--- a/src/trcaret/Program.cs
+++ b/src/trcaret/Program.cs
@@ -35,7 +35,7 @@ namespace Trash
                 {
                     h.AdditionalNewLineAfterOption = false;
                     h.Heading = "trcaret";
-                    h.Copyright = "Copyright (c) 2023 Ken Domino"; //change copyright text
+                    h.Copyright = "Copyright (c) 2026 Ken Domino"; //change copyright text
                     h.AddPreOptionsText(new Command().Help());
                     return HelpText.DefaultParsingErrorsHandler(result, h);
                 }, e => e);

--- a/src/trcaret/readme.md
+++ b/src/trcaret/readme.md
@@ -24,7 +24,7 @@ Reads a tree from stdin and prints lines and caret marks.
 
 The MIT License
 
-Copyright (c) 2025 Ken Domino
+Copyright (c) 2026 Ken Domino
 
 Permission is hereby granted, free of charge, 
 to any person obtaining a copy of this software and 

--- a/src/trclonereplace/Program.cs
+++ b/src/trclonereplace/Program.cs
@@ -35,7 +35,7 @@ public class Program
             {
                 h.AdditionalNewLineAfterOption = false;
                 h.Heading = "trrename";
-                h.Copyright = "Copyright (c) 2023 Ken Domino"; //change copyright text
+                h.Copyright = "Copyright (c) 2026 Ken Domino"; //change copyright text
                 h.AddPreOptionsText(new Command().Help());
                 return HelpText.DefaultParsingErrorsHandler(result, h);
             }, e => e);

--- a/src/trclonereplace/readme.md
+++ b/src/trclonereplace/readme.md
@@ -25,7 +25,7 @@ Clone, rename, and replace symbols in a grammar to optimize full stack fallbacks
 
 The MIT License
 
-Copyright (c) 2025 Ken Domino
+Copyright (c) 2026 Ken Domino
 
 Permission is hereby granted, free of charge, 
 to any person obtaining a copy of this software and 

--- a/src/trcombine/Program.cs
+++ b/src/trcombine/Program.cs
@@ -35,7 +35,7 @@ namespace Trash
                 {
                     h.AdditionalNewLineAfterOption = false;
                     h.Heading = "trcombine";
-                    h.Copyright = "Copyright (c) 2023 Ken Domino";
+                    h.Copyright = "Copyright (c) 2026 Ken Domino";
                     h.AddPreOptionsText(new Command().Help());
                     return HelpText.DefaultParsingErrorsHandler(result, h);
                 }, e => e);

--- a/src/trcombine/readme.md
+++ b/src/trcombine/readme.md
@@ -109,7 +109,7 @@ The original grammars are left unchanged.
 
 The MIT License
 
-Copyright (c) 2025 Ken Domino
+Copyright (c) 2026 Ken Domino
 
 Permission is hereby granted, free of charge, 
 to any person obtaining a copy of this software and 

--- a/src/trconvert/Program.cs
+++ b/src/trconvert/Program.cs
@@ -35,7 +35,7 @@ namespace Trash
                 {
                     h.AdditionalNewLineAfterOption = false;
                     h.Heading = "trconvert";
-                    h.Copyright = "Copyright (c) 2023 Ken Domino"; //change copyright text
+                    h.Copyright = "Copyright (c) 2026 Ken Domino"; //change copyright text
                     h.AddPreOptionsText(new Command().Help());
                     return HelpText.DefaultParsingErrorsHandler(result, h);
                 }, e => e);

--- a/src/trconvert/readme.md
+++ b/src/trconvert/readme.md
@@ -99,7 +99,7 @@ _Output_
 
 The MIT License
 
-Copyright (c) 2025 Ken Domino
+Copyright (c) 2026 Ken Domino
 
 Permission is hereby granted, free of charge, 
 to any person obtaining a copy of this software and 

--- a/src/trcover/Program.cs
+++ b/src/trcover/Program.cs
@@ -35,7 +35,7 @@ namespace Trash
                 {
                     h.AdditionalNewLineAfterOption = false;
                     h.Heading = "trcover";
-                    h.Copyright = "Copyright (c) 2023 Ken Domino"; //change copyright text
+                    h.Copyright = "Copyright (c) 2026 Ken Domino"; //change copyright text
                     h.AddPreOptionsText(new Command().Help());
                     return HelpText.DefaultParsingErrorsHandler(result, h);
                 }, e => e);

--- a/src/trcover/readme.md
+++ b/src/trcover/readme.md
@@ -30,7 +30,7 @@ a grammar.
 
 The MIT License
 
-Copyright (c) 2025 Ken Domino
+Copyright (c) 2026 Ken Domino
 
 Permission is hereby granted, free of charge, 
 to any person obtaining a copy of this software and 

--- a/src/trdistill/Program.cs
+++ b/src/trdistill/Program.cs
@@ -35,7 +35,7 @@ public class Program
             {
                 h.AdditionalNewLineAfterOption = false;
                 h.Heading = "trconvert";
-                h.Copyright = "Copyright (c) 2025 Ken Domino"; //change copyright text
+                h.Copyright = "Copyright (c) 2026 Ken Domino"; //change copyright text
                 h.AddPreOptionsText(new Command().Help());
                 return HelpText.DefaultParsingErrorsHandler(result, h);
             }, e => e);

--- a/src/trdistill/readme.md
+++ b/src/trdistill/readme.md
@@ -99,7 +99,7 @@ _Output_
 
 The MIT License
 
-Copyright (c) 2025 Ken Domino
+Copyright (c) 2026 Ken Domino
 
 Permission is hereby granted, free of charge, 
 to any person obtaining a copy of this software and 

--- a/src/trdot/Program.cs
+++ b/src/trdot/Program.cs
@@ -35,7 +35,7 @@ namespace Trash
                 {
                     h.AdditionalNewLineAfterOption = false;
                     h.Heading = "trdot";
-                    h.Copyright = "Copyright (c) 2023 Ken Domino"; //change copyright text
+                    h.Copyright = "Copyright (c) 2026 Ken Domino"; //change copyright text
                     h.AddPreOptionsText(new Command().Help());
                     return HelpText.DefaultParsingErrorsHandler(result, h);
                 }, e => e);

--- a/src/trdot/readme.md
+++ b/src/trdot/readme.md
@@ -69,7 +69,7 @@ The output will be:
 
 The MIT License
 
-Copyright (c) 2025 Ken Domino
+Copyright (c) 2026 Ken Domino
 
 Permission is hereby granted, free of charge, 
 to any person obtaining a copy of this software and 

--- a/src/trenum/Program.cs
+++ b/src/trenum/Program.cs
@@ -31,7 +31,7 @@ namespace Trash
                 {
                     h.AdditionalNewLineAfterOption = false;
                     h.Heading = "trenum";
-                    h.Copyright = "Copyright (c) 2023 Ken Domino"; //change copyright text
+                    h.Copyright = "Copyright (c) 2026 Ken Domino"; //change copyright text
                     h.AddPreOptionsText(new Command().Help());
                     return HelpText.DefaultParsingErrorsHandler(result, h);
                 }, e => e);

--- a/src/trenum/readme.md
+++ b/src/trenum/readme.md
@@ -14,7 +14,7 @@
 
 The MIT License
 
-Copyright (c) 2025 Ken Domino
+Copyright (c) 2026 Ken Domino
 
 Permission is hereby granted, free of charge, 
 to any person obtaining a copy of this software and 

--- a/src/trextract/Program.cs
+++ b/src/trextract/Program.cs
@@ -35,7 +35,7 @@ namespace Trash
                 {
                     h.AdditionalNewLineAfterOption = false;
                     h.Heading = "trextract";
-                    h.Copyright = "Copyright (c) 2024 Ken Domino";
+                    h.Copyright = "Copyright (c) 2026 Ken Domino";
                     h.AddPreOptionsText(new Command().Help());
                     return HelpText.DefaultParsingErrorsHandler(result, h);
                 }, e => e);

--- a/src/trextract/readme.md
+++ b/src/trextract/readme.md
@@ -39,7 +39,7 @@ The outputed files are:
 
 The MIT License
 
-Copyright (c) 2025 Ken Domino
+Copyright (c) 2026 Ken Domino
 
 Permission is hereby granted, free of charge, 
 to any person obtaining a copy of this software and 

--- a/src/trff/Program.cs
+++ b/src/trff/Program.cs
@@ -35,7 +35,7 @@ namespace Trash
                 {
                     h.AdditionalNewLineAfterOption = false;
                     h.Heading = "trff";
-                    h.Copyright = "Copyright (c) 2023 Ken Domino";
+                    h.Copyright = "Copyright (c) 2026 Ken Domino";
                     h.AddPreOptionsText(new Command().Help());
                     return HelpText.DefaultParsingErrorsHandler(result, h);
                 }, e => e);

--- a/src/trff/readme.md
+++ b/src/trff/readme.md
@@ -28,7 +28,7 @@ XPaths, type _export MSYS2_ARG_CONV_EXCL="*"_, then execute your command.
 
 The MIT License
 
-Copyright (c) 2025 Ken Domino
+Copyright (c) 2026 Ken Domino
 
 Permission is hereby granted, free of charge, 
 to any person obtaining a copy of this software and 

--- a/src/trfold/Program.cs
+++ b/src/trfold/Program.cs
@@ -35,7 +35,7 @@ public class Program
             {
                 h.AdditionalNewLineAfterOption = false;
                 h.Heading = "trfold";
-                h.Copyright = "Copyright (c) 2023 Ken Domino"; //change copyright text
+                h.Copyright = "Copyright (c) 2026 Ken Domino"; //change copyright text
                 h.AddPreOptionsText(new Command().Help());
                 return HelpText.DefaultParsingErrorsHandler(result, h);
             }, e => e);

--- a/src/trfold/readme.md
+++ b/src/trfold/readme.md
@@ -32,7 +32,7 @@ XPaths, type _export MSYS2_ARG_CONV_EXCL="*"_, then execute your command.
 
 The MIT License
 
-Copyright (c) 2025 Ken Domino
+Copyright (c) 2026 Ken Domino
 
 Permission is hereby granted, free of charge, 
 to any person obtaining a copy of this software and 

--- a/src/trfoldlit/Program.cs
+++ b/src/trfoldlit/Program.cs
@@ -35,7 +35,7 @@ public class Program
             {
                 h.AdditionalNewLineAfterOption = false;
                 h.Heading = "trfoldlit";
-                h.Copyright = "Copyright (c) 2023 Ken Domino"; //change copyright text
+                h.Copyright = "Copyright (c) 2026 Ken Domino"; //change copyright text
                 h.AddPreOptionsText(new Command().Help());
                 return HelpText.DefaultParsingErrorsHandler(result, h);
             }, e => e);

--- a/src/trfoldlit/readme.md
+++ b/src/trfoldlit/readme.md
@@ -71,7 +71,7 @@ XPaths, type _export MSYS2_ARG_CONV_EXCL="*"_, then execute your command.
 
 The MIT License
 
-Copyright (c) 2025 Ken Domino
+Copyright (c) 2026 Ken Domino
 
 Permission is hereby granted, free of charge, 
 to any person obtaining a copy of this software and 

--- a/src/trformat/Program.cs
+++ b/src/trformat/Program.cs
@@ -37,7 +37,7 @@ public class Program
             {
                 h.AdditionalNewLineAfterOption = false;
                 h.Heading = "trformat";
-                h.Copyright = "Copyright (c) 2023 Ken Domino"; //change copyright text
+                h.Copyright = "Copyright (c) 2026 Ken Domino"; //change copyright text
                 h.AddPreOptionsText(new Command().Help());
                 return HelpText.DefaultParsingErrorsHandler(result, h);
             }, e => e);

--- a/src/trformat/readme.md
+++ b/src/trformat/readme.md
@@ -24,7 +24,7 @@ Format of grammar using machine learning.
 
 The MIT License
 
-Copyright (c) 2025 Ken Domino
+Copyright (c) 2026 Ken Domino
 
 Permission is hereby granted, free of charge, 
 to any person obtaining a copy of this software and 

--- a/src/trgen/Program.cs
+++ b/src/trgen/Program.cs
@@ -38,7 +38,7 @@ namespace Trash
                 {
                     h.AdditionalNewLineAfterOption = false;
                     h.Heading = "trgen";
-                    h.Copyright = "Copyright (c) 2023 Ken Domino";
+                    h.Copyright = "Copyright (c) 2026 Ken Domino";
                     h.AddPreOptionsText(new Command().Help());
                     return HelpText.DefaultParsingErrorsHandler(result, h);
                 }, e => e);

--- a/src/trgen/readme.md
+++ b/src/trgen/readme.md
@@ -89,7 +89,7 @@ After all files are parsed, six summary lines are printed:
 
 The MIT License
 
-Copyright (c) 2025 Ken Domino
+Copyright (c) 2026 Ken Domino
 
 Permission is hereby granted, free of charge, 
 to any person obtaining a copy of this software and 

--- a/src/trgenvsc/Program.cs
+++ b/src/trgenvsc/Program.cs
@@ -38,7 +38,7 @@ namespace Trash
                 {
                     h.AdditionalNewLineAfterOption = false;
                     h.Heading = "trgenvsc";
-                    h.Copyright = "Copyright (c) 2024 Ken Domino";
+                    h.Copyright = "Copyright (c) 2026 Ken Domino";
                     h.AddPreOptionsText(new Command().Help());
                     return HelpText.DefaultParsingErrorsHandler(result, h);
                 }, e => e);

--- a/src/trgenvsc/readme.md
+++ b/src/trgenvsc/readme.md
@@ -36,7 +36,7 @@ the XPath patterns to match certain parse trees.
 
 The MIT License
 
-Copyright (c) 2025 Ken Domino
+Copyright (c) 2026 Ken Domino
 
 Permission is hereby granted, free of charge, 
 to any person obtaining a copy of this software and 

--- a/src/trgenvsc/templates/LICENSE
+++ b/src/trgenvsc/templates/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 Ken Domino
+Copyright (c) 2021-2026 Ken Domino
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/trglob/Program.cs
+++ b/src/trglob/Program.cs
@@ -37,7 +37,7 @@ public partial class Program
             {
                 h.AdditionalNewLineAfterOption = false;
                 h.Heading = "trglob";
-                h.Copyright = "Copyright (c) 2023 Ken Domino";
+                h.Copyright = "Copyright (c) 2026 Ken Domino";
                 h.AddPreOptionsText(new Command().Help());
                 return HelpText.DefaultParsingErrorsHandler(result, h);
             }, e => e);

--- a/src/trglob/readme.md
+++ b/src/trglob/readme.md
@@ -23,7 +23,7 @@ Expand a glob string into file names.
 
 The MIT License
 
-Copyright (c) 2025 Ken Domino
+Copyright (c) 2026 Ken Domino
 
 Permission is hereby granted, free of charge, 
 to any person obtaining a copy of this software and 

--- a/src/trgroup/Program.cs
+++ b/src/trgroup/Program.cs
@@ -35,7 +35,7 @@ namespace Trash
 				{
 					h.AdditionalNewLineAfterOption = false;
 					h.Heading = "trgroup";
-					h.Copyright = "Copyright (c) 2023 Ken Domino"; //change copyright text
+					h.Copyright = "Copyright (c) 2026 Ken Domino"; //change copyright text
 					h.AddPreOptionsText(new Command().Help());
 					return HelpText.DefaultParsingErrorsHandler(result, h);
 				}, e => e);

--- a/src/trgroup/readme.md
+++ b/src/trgroup/readme.md
@@ -62,7 +62,7 @@ XPaths, type _export MSYS2_ARG_CONV_EXCL="*"_, then execute your command.
 
 The MIT License
 
-Copyright (c) 2025 Ken Domino
+Copyright (c) 2026 Ken Domino
 
 Permission is hereby granted, free of charge, 
 to any person obtaining a copy of this software and 

--- a/src/triconv/Program.cs
+++ b/src/triconv/Program.cs
@@ -35,7 +35,7 @@ class Program
             {
                 h.AdditionalNewLineAfterOption = false;
                 h.Heading = "triconv";
-                h.Copyright = "Copyright (c) 2023 Ken Domino"; //change copyright text
+                h.Copyright = "Copyright (c) 2026 Ken Domino"; //change copyright text
                 h.AddPreOptionsText(new Command().Help());
                 return HelpText.DefaultParsingErrorsHandler(result, h);
             }, e => e);

--- a/src/triconv/readme.md
+++ b/src/triconv/readme.md
@@ -26,7 +26,7 @@ unicode.
 
 The MIT License
 
-Copyright (c) 2025 Ken Domino
+Copyright (c) 2026 Ken Domino
 
 Permission is hereby granted, free of charge, 
 to any person obtaining a copy of this software and 

--- a/src/trinterp/Program.cs
+++ b/src/trinterp/Program.cs
@@ -35,7 +35,7 @@ public class Program
             {
                 h.AdditionalNewLineAfterOption = false;
                 h.Heading = "trinterp";
-                h.Copyright = "Copyright (c) 2025 Ken Domino";
+                h.Copyright = "Copyright (c) 2026 Ken Domino";
                 h.AddPreOptionsText(new Command().Help());
                 return HelpText.DefaultParsingErrorsHandler(result, h);
             }, e => e);

--- a/src/trinterp/readme.md
+++ b/src/trinterp/readme.md
@@ -39,7 +39,7 @@ consume them without needing the generated target-language source.
 
 The MIT License
 
-Copyright (c) 2025 Ken Domino
+Copyright (c) 2026 Ken Domino
 
 Permission is hereby granted, free of charge,
 to any person obtaining a copy of this software and

--- a/src/tritext/Command.cs
+++ b/src/tritext/Command.cs
@@ -1,7 +1,7 @@
 ﻿/*
 MIT License
 
-Copyright (c) 2023 Ken Domino
+Copyright (c) 2026 Ken Domino
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/tritext/Program.cs
+++ b/src/tritext/Program.cs
@@ -36,7 +36,7 @@ public class Program
             {
                 h.AdditionalNewLineAfterOption = false;
                 h.Heading = "tritext";
-                h.Copyright = "Copyright (c) 2023 Ken Domino"; //change copyright text
+                h.Copyright = "Copyright (c) 2026 Ken Domino"; //change copyright text
                 h.AddPreOptionsText(new Command().Help());
                 return HelpText.DefaultParsingErrorsHandler(result, h);
             }, e => e);

--- a/src/tritext/readme.md
+++ b/src/tritext/readme.md
@@ -24,7 +24,7 @@ Get strings from a PDF file using IText.
 
 The MIT License
 
-Copyright (c) 2025 Ken Domino
+Copyright (c) 2026 Ken Domino
 
 Permission is hereby granted, free of charge, 
 to any person obtaining a copy of this software and 

--- a/src/trjson/Program.cs
+++ b/src/trjson/Program.cs
@@ -35,7 +35,7 @@ public class Program
             {
                 h.AdditionalNewLineAfterOption = false;
                 h.Heading = "trjson";
-                h.Copyright = "Copyright (c) 2023 Ken Domino"; //change copyright text
+                h.Copyright = "Copyright (c) 2026 Ken Domino"; //change copyright text
                 h.AddPreOptionsText(new Command().Help());
                 return HelpText.DefaultParsingErrorsHandler(result, h);
             }, e => e);

--- a/src/trjson/readme.md
+++ b/src/trjson/readme.md
@@ -24,7 +24,7 @@ Read a parse tree from stdin and write a JSON represenation of it.
 
 The MIT License
 
-Copyright (c) 2025 Ken Domino
+Copyright (c) 2026 Ken Domino
 
 Permission is hereby granted, free of charge, 
 to any person obtaining a copy of this software and 

--- a/src/trkleene/Program.cs
+++ b/src/trkleene/Program.cs
@@ -35,7 +35,7 @@ namespace Trash
 				{
 					h.AdditionalNewLineAfterOption = false;
 					h.Heading = "trkleene";
-					h.Copyright = "Copyright (c) 2023 Ken Domino"; //change copyright text
+					h.Copyright = "Copyright (c) 2026 Ken Domino"; //change copyright text
 					h.AddPreOptionsText(new Command().Help());
 					return HelpText.DefaultParsingErrorsHandler(result, h);
 				}, e => e);

--- a/src/trkleene/readme.md
+++ b/src/trkleene/readme.md
@@ -44,7 +44,7 @@ XPaths, type _export MSYS2_ARG_CONV_EXCL="*"_, then execute your command.
 
 The MIT License
 
-Copyright (c) 2025 Ken Domino
+Copyright (c) 2026 Ken Domino
 
 Permission is hereby granted, free of charge, 
 to any person obtaining a copy of this software and 

--- a/src/trnullable/Program.cs
+++ b/src/trnullable/Program.cs
@@ -35,7 +35,7 @@ public class Program
             {
                 h.AdditionalNewLineAfterOption = false;
                 h.Heading = "trnullable";
-                h.Copyright = "Copyright (c) 2024 Ken Domino"; //change copyright text
+                h.Copyright = "Copyright (c) 2026 Ken Domino"; //change copyright text
                 h.AddPreOptionsText(new Command().Help());
                 return HelpText.DefaultParsingErrorsHandler(result, h);
             }, e => e);

--- a/src/trnullable/readme.md
+++ b/src/trnullable/readme.md
@@ -24,7 +24,7 @@ trparse A.g4 | trnullable
 
 The MIT License
 
-Copyright (c) 2025 Ken Domino
+Copyright (c) 2026 Ken Domino
 
 Permission is hereby granted, free of charge, 
 to any person obtaining a copy of this software and 

--- a/src/trparse/Program.cs
+++ b/src/trparse/Program.cs
@@ -38,7 +38,7 @@ public class Program
             {
                 h.AdditionalNewLineAfterOption = false;
                 h.Heading = "trparse";
-                h.Copyright = "Copyright (c) 2023 Ken Domino"; //change copyright text
+                h.Copyright = "Copyright (c) 2026 Ken Domino"; //change copyright text
                 h.AddPreOptionsText(new Command().Help());
                 return HelpText.DefaultParsingErrorsHandler(result, h);
             }, e => e);

--- a/src/trparse/readme.md
+++ b/src/trparse/readme.md
@@ -92,7 +92,7 @@ works without modification.
 
 The MIT License
 
-Copyright (c) 2025 Ken Domino
+Copyright (c) 2026 Ken Domino
 
 Permission is hereby granted, free of charge, 
 to any person obtaining a copy of this software and 

--- a/src/trperf/Program.cs
+++ b/src/trperf/Program.cs
@@ -36,7 +36,7 @@ public class Program
             {
                 h.AdditionalNewLineAfterOption = false;
                 h.Heading = "trperf";
-                h.Copyright = "Copyright (c) 2023 Ken Domino"; //change copyright text
+                h.Copyright = "Copyright (c) 2026 Ken Domino"; //change copyright text
                 h.AddPreOptionsText(new Command().Help());
                 return HelpText.DefaultParsingErrorsHandler(result, h);
             }, e => e);

--- a/src/trperf/readme.md
+++ b/src/trperf/readme.md
@@ -73,7 +73,7 @@ be in a trgen-generated parser directory, or use the -p option.
 
 The MIT License
 
-Copyright (c) 2025 Ken Domino
+Copyright (c) 2026 Ken Domino
 
 Permission is hereby granted, free of charge, 
 to any person obtaining a copy of this software and 

--- a/src/trpiggy/Program.cs
+++ b/src/trpiggy/Program.cs
@@ -41,7 +41,7 @@ namespace Trash
                 {
                     h.AdditionalNewLineAfterOption = false;
                     h.Heading = "trpiggy";
-                    h.Copyright = "Copyright (c) 2023 Ken Domino";
+                    h.Copyright = "Copyright (c) 2026 Ken Domino";
                     h.AddPreOptionsText(new Command().Help());
                     return HelpText.DefaultParsingErrorsHandler(result, h);
                 }, e => e);

--- a/src/trpiggy/readme.md
+++ b/src/trpiggy/readme.md
@@ -69,7 +69,7 @@ Output:
 
 The MIT License
 
-Copyright (c) 2025 Ken Domino
+Copyright (c) 2026 Ken Domino
 
 Permission is hereby granted, free of charge, 
 to any person obtaining a copy of this software and 

--- a/src/trquery/Program.cs
+++ b/src/trquery/Program.cs
@@ -35,7 +35,7 @@ public class Program
             {
                 h.AdditionalNewLineAfterOption = false;
                 h.Heading = "trinsert";
-                h.Copyright = "Copyright (c) 2023 Ken Domino"; //change copyright text
+                h.Copyright = "Copyright (c) 2026 Ken Domino"; //change copyright text
                 h.AddPreOptionsText(new Command().Help());
                 return HelpText.DefaultParsingErrorsHandler(result, h);
             }, e => e);

--- a/src/trquery/readme.md
+++ b/src/trquery/readme.md
@@ -53,7 +53,7 @@ XPaths, type _export MSYS2_ARG_CONV_EXCL="*"_, then execute your command.
 
 The MIT License
 
-Copyright (c) 2025 Ken Domino
+Copyright (c) 2026 Ken Domino
 
 Permission is hereby granted, free of charge, 
 to any person obtaining a copy of this software and 

--- a/src/trrename/Program.cs
+++ b/src/trrename/Program.cs
@@ -35,7 +35,7 @@ public class Program
             {
                 h.AdditionalNewLineAfterOption = false;
                 h.Heading = "trrename";
-                h.Copyright = "Copyright (c) 2023 Ken Domino"; //change copyright text
+                h.Copyright = "Copyright (c) 2026 Ken Domino"; //change copyright text
                 h.AddPreOptionsText(new Command().Help());
                 return HelpText.DefaultParsingErrorsHandler(result, h);
             }, e => e);

--- a/src/trrename/readme.md
+++ b/src/trrename/readme.md
@@ -33,7 +33,7 @@ make sure to enclose the argument as it contains semi-colons.
 
 The MIT License
 
-Copyright (c) 2025 Ken Domino
+Copyright (c) 2026 Ken Domino
 
 Permission is hereby granted, free of charge, 
 to any person obtaining a copy of this software and 

--- a/src/trrr/Program.cs
+++ b/src/trrr/Program.cs
@@ -35,7 +35,7 @@ namespace Trash
                 {
                     h.AdditionalNewLineAfterOption = false;
                     h.Heading = "trrr";
-                    h.Copyright = "Copyright (c) 2023 Ken Domino";
+                    h.Copyright = "Copyright (c) 2026 Ken Domino";
                     h.AddPreOptionsText(new Command().Help());
                     return HelpText.DefaultParsingErrorsHandler(result, h);
                 }, e => e);

--- a/src/trrr/readme.md
+++ b/src/trrr/readme.md
@@ -20,7 +20,7 @@
 
 The MIT License
 
-Copyright (c) 2025 Ken Domino
+Copyright (c) 2026 Ken Domino
 
 Permission is hereby granted, free of charge, 
 to any person obtaining a copy of this software and 

--- a/src/trrup/Program.cs
+++ b/src/trrup/Program.cs
@@ -35,7 +35,7 @@ namespace Trash
                 {
                     h.AdditionalNewLineAfterOption = false;
                     h.Heading = "trrup";
-                    h.Copyright = "Copyright (c) 2023 Ken Domino";
+                    h.Copyright = "Copyright (c) 2026 Ken Domino";
                     h.AddPreOptionsText(new Command().Help());
                     return HelpText.DefaultParsingErrorsHandler(result, h);
                 }, e => e);

--- a/src/trrup/readme.md
+++ b/src/trrup/readme.md
@@ -48,7 +48,7 @@ XPaths, type _export MSYS2_ARG_CONV_EXCL="*"_, then execute your command.
 
 The MIT License
 
-Copyright (c) 2025 Ken Domino
+Copyright (c) 2026 Ken Domino
 
 Permission is hereby granted, free of charge, 
 to any person obtaining a copy of this software and 

--- a/src/trsem/Program.cs
+++ b/src/trsem/Program.cs
@@ -41,7 +41,7 @@ namespace Trash
                 {
                     h.AdditionalNewLineAfterOption = false;
                     h.Heading = "trsem";
-                    h.Copyright = "Copyright (c) 2023 Ken Domino";
+                    h.Copyright = "Copyright (c) 2026 Ken Domino";
                     h.AddPreOptionsText(new Command().Help());
                     return HelpText.DefaultParsingErrorsHandler(result, h);
                 }, e => e);

--- a/src/trsem/readme.md
+++ b/src/trsem/readme.md
@@ -24,7 +24,7 @@ Read a static semantics spec file and generate code.
 
 The MIT License
 
-Copyright (c) 2025 Ken Domino
+Copyright (c) 2026 Ken Domino
 
 Permission is hereby granted, free of charge, 
 to any person obtaining a copy of this software and 

--- a/src/trsort/Program.cs
+++ b/src/trsort/Program.cs
@@ -35,7 +35,7 @@ namespace Trash
                 {
                     h.AdditionalNewLineAfterOption = false;
                     h.Heading = "trsort";
-                    h.Copyright = "Copyright (c) 2023 Ken Domino"; //change copyright text
+                    h.Copyright = "Copyright (c) 2026 Ken Domino"; //change copyright text
                     h.AddPreOptionsText(new Command().Help());
                     return HelpText.DefaultParsingErrorsHandler(result, h);
                 }, e => e);

--- a/src/trsort/readme.md
+++ b/src/trsort/readme.md
@@ -48,7 +48,7 @@ Only one mode flag may be specified at a time.
 
 The MIT License
 
-Copyright (c) 2025 Ken Domino
+Copyright (c) 2026 Ken Domino
 
 Permission is hereby granted, free of charge, 
 to any person obtaining a copy of this software and 

--- a/src/trsplit/Program.cs
+++ b/src/trsplit/Program.cs
@@ -35,7 +35,7 @@ public class Program
             {
                 h.AdditionalNewLineAfterOption = false;
                 h.Heading = "trsplit";
-                h.Copyright = "Copyright (c) 2023 Ken Domino";
+                h.Copyright = "Copyright (c) 2026 Ken Domino";
                 h.AddPreOptionsText(new Command().Help());
                 return HelpText.DefaultParsingErrorsHandler(result, h);
             }, e => e);

--- a/src/trsplit/readme.md
+++ b/src/trsplit/readme.md
@@ -51,7 +51,7 @@ modified.
 
 The MIT License
 
-Copyright (c) 2025 Ken Domino
+Copyright (c) 2026 Ken Domino
 
 Permission is hereby granted, free of charge, 
 to any person obtaining a copy of this software and 

--- a/src/trsponge/Program.cs
+++ b/src/trsponge/Program.cs
@@ -35,7 +35,7 @@ public class Program
             {
                 h.AdditionalNewLineAfterOption = false;
                 h.Heading = "trsponge";
-                h.Copyright = "Copyright (c) 2023 Ken Domino";
+                h.Copyright = "Copyright (c) 2026 Ken Domino";
                 h.AddPreOptionsText(new Command().Help());
                 return HelpText.DefaultParsingErrorsHandler(result, h);
             }, e => e);

--- a/src/trsponge/readme.md
+++ b/src/trsponge/readme.md
@@ -25,7 +25,7 @@ results to file(s).
 
 The MIT License
 
-Copyright (c) 2025 Ken Domino
+Copyright (c) 2026 Ken Domino
 
 Permission is hereby granted, free of charge, 
 to any person obtaining a copy of this software and 

--- a/src/trtext/Program.cs
+++ b/src/trtext/Program.cs
@@ -35,7 +35,7 @@ public class Program
             {
                 h.AdditionalNewLineAfterOption = false;
                 h.Heading = "trtext";
-                h.Copyright = "Copyright (c) 2023 Ken Domino"; //change copyright text
+                h.Copyright = "Copyright (c) 2026 Ken Domino"; //change copyright text
                 h.AddPreOptionsText(new Command().Help());
                 return HelpText.DefaultParsingErrorsHandler(result, h);
             }, e => e);

--- a/src/trtext/readme.md
+++ b/src/trtext/readme.md
@@ -25,7 +25,7 @@ specified, the line number range for the tree is printed.
 
 The MIT License
 
-Copyright (c) 2025 Ken Domino
+Copyright (c) 2026 Ken Domino
 
 Permission is hereby granted, free of charge, 
 to any person obtaining a copy of this software and 

--- a/src/trthompson/Program.cs
+++ b/src/trthompson/Program.cs
@@ -37,7 +37,7 @@ namespace Trash
                 {
                     h.AdditionalNewLineAfterOption = false;
                     h.Heading = "trthompson";
-                    h.Copyright = "Copyright (c) 2023 Ken Domino"; //change copyright text
+                    h.Copyright = "Copyright (c) 2026 Ken Domino"; //change copyright text
                     h.AddPreOptionsText(new Command().Help());
                     return HelpText.DefaultParsingErrorsHandler(result, h);
                 }, e => e);

--- a/src/trthompson/readme.md
+++ b/src/trthompson/readme.md
@@ -18,7 +18,7 @@
 
 The MIT License
 
-Copyright (c) 2025 Ken Domino
+Copyright (c) 2026 Ken Domino
 
 Permission is hereby granted, free of charge, 
 to any person obtaining a copy of this software and 

--- a/src/trtokens/Program.cs
+++ b/src/trtokens/Program.cs
@@ -35,7 +35,7 @@ public class Program
             {
                 h.AdditionalNewLineAfterOption = false;
                 h.Heading = "trtokens";
-                h.Copyright = "Copyright (c) 2023 Ken Domino"; //change copyright text
+                h.Copyright = "Copyright (c) 2026 Ken Domino"; //change copyright text
                 h.AddPreOptionsText(new Command().Help());
                 return HelpText.DefaultParsingErrorsHandler(result, h);
             }, e => e);

--- a/src/trtokens/readme.md
+++ b/src/trtokens/readme.md
@@ -58,7 +58,7 @@ Output:
 
 The MIT License
 
-Copyright (c) 2025 Ken Domino
+Copyright (c) 2026 Ken Domino
 
 Permission is hereby granted, free of charge, 
 to any person obtaining a copy of this software and 

--- a/src/trtree/Program.cs
+++ b/src/trtree/Program.cs
@@ -36,7 +36,7 @@ public class Program
             {
                 h.AdditionalNewLineAfterOption = false;
                 h.Heading = "trtree";
-                h.Copyright = "Copyright (c) 2023 Ken Domino"; //change copyright text
+                h.Copyright = "Copyright (c) 2026 Ken Domino"; //change copyright text
                 h.AddPreOptionsText(new Command().Help());
                 return HelpText.DefaultParsingErrorsHandler(result, h);
             }, e => e);

--- a/src/trtree/readme.md
+++ b/src/trtree/readme.md
@@ -24,7 +24,7 @@ Reads a tree from stdin and prints the tree as an indented node list.
 
 The MIT License
 
-Copyright (c) 2025 Ken Domino
+Copyright (c) 2026 Ken Domino
 
 Permission is hereby granted, free of charge, 
 to any person obtaining a copy of this software and 

--- a/src/trull/Program.cs
+++ b/src/trull/Program.cs
@@ -35,7 +35,7 @@ namespace Trash
                 {
                     h.AdditionalNewLineAfterOption = false;
                     h.Heading = "trull";
-                    h.Copyright = "Copyright (c) 2023 Ken Domino"; //change copyright text
+                    h.Copyright = "Copyright (c) 2026 Ken Domino"; //change copyright text
                     h.AddPreOptionsText(new Command().Help());
                     return HelpText.DefaultParsingErrorsHandler(result, h);
                 }, e => e);

--- a/src/trull/readme.md
+++ b/src/trull/readme.md
@@ -69,7 +69,7 @@ XPaths, type _export MSYS2_ARG_CONV_EXCL="*"_, then execute your command.
 
 The MIT License
 
-Copyright (c) 2025 Ken Domino
+Copyright (c) 2026 Ken Domino
 
 Permission is hereby granted, free of charge, 
 to any person obtaining a copy of this software and 

--- a/src/trunfold/Program.cs
+++ b/src/trunfold/Program.cs
@@ -35,7 +35,7 @@ public class Program
             {
                 h.AdditionalNewLineAfterOption = false;
                 h.Heading = "trunfold";
-                h.Copyright = "Copyright (c) 2023 Ken Domino"; //change copyright text
+                h.Copyright = "Copyright (c) 2026 Ken Domino"; //change copyright text
                 h.AddPreOptionsText(new Command().Help());
                 return HelpText.DefaultParsingErrorsHandler(result, h);
             }, e => e);

--- a/src/trunfold/readme.md
+++ b/src/trunfold/readme.md
@@ -57,7 +57,7 @@ XPaths, type _export MSYS2_ARG_CONV_EXCL="*"_, then execute your command.
 
 The MIT License
 
-Copyright (c) 2025 Ken Domino
+Copyright (c) 2026 Ken Domino
 
 Permission is hereby granted, free of charge, 
 to any person obtaining a copy of this software and 

--- a/src/trunfoldlit/Program.cs
+++ b/src/trunfoldlit/Program.cs
@@ -34,7 +34,7 @@ public class Program
             {
                 h.AdditionalNewLineAfterOption = false;
                 h.Heading = "trunfoldlit";
-                h.Copyright = "Copyright (c) 2025 Ken Domino"; //change copyright text
+                h.Copyright = "Copyright (c) 2026 Ken Domino"; //change copyright text
                 h.AddPreOptionsText(new Command().Help());
                 return HelpText.DefaultParsingErrorsHandler(result, h);
             }, e => e);

--- a/src/trunfoldlit/readme.md
+++ b/src/trunfoldlit/readme.md
@@ -57,7 +57,7 @@ XPaths, type _export MSYS2_ARG_CONV_EXCL="*"_, then execute your command.
 
 The MIT License
 
-Copyright (c) 2025 Ken Domino
+Copyright (c) 2026 Ken Domino
 
 Permission is hereby granted, free of charge, 
 to any person obtaining a copy of this software and 

--- a/src/trungroup/Program.cs
+++ b/src/trungroup/Program.cs
@@ -35,7 +35,7 @@ public class Program
             {
                 h.AdditionalNewLineAfterOption = false;
                 h.Heading = "trungroup";
-                h.Copyright = "Copyright (c) 2023 Ken Domino"; //change copyright text
+                h.Copyright = "Copyright (c) 2026 Ken Domino"; //change copyright text
                 h.AddPreOptionsText(new Command().Help());
                 return HelpText.DefaultParsingErrorsHandler(result, h);
             }, e => e);

--- a/src/trungroup/readme.md
+++ b/src/trungroup/readme.md
@@ -30,7 +30,7 @@ XPaths, type _export MSYS2_ARG_CONV_EXCL="*"_, then execute your command.
 
 The MIT License
 
-Copyright (c) 2025 Ken Domino
+Copyright (c) 2026 Ken Domino
 
 Permission is hereby granted, free of charge, 
 to any person obtaining a copy of this software and 

--- a/src/trwdog/Program.cs
+++ b/src/trwdog/Program.cs
@@ -39,7 +39,7 @@ class Program
             {
                 h.AdditionalNewLineAfterOption = false;
                 h.Heading = "trwdog";
-                h.Copyright = "Copyright (c) 2023 Ken Domino"; //change copyright text
+                h.Copyright = "Copyright (c) 2026 Ken Domino"; //change copyright text
                 h.AddPreOptionsText(new Command().Help());
                 return HelpText.DefaultParsingErrorsHandler(result, h);
             }, e => e);

--- a/src/trwdog/readme.md
+++ b/src/trwdog/readme.md
@@ -24,7 +24,7 @@ Execute a command with a watchdog timer.
 
 The MIT License
 
-Copyright (c) 2025 Ken Domino
+Copyright (c) 2026 Ken Domino
 
 Permission is hereby granted, free of charge, 
 to any person obtaining a copy of this software and 

--- a/src/trxml/Program.cs
+++ b/src/trxml/Program.cs
@@ -35,7 +35,7 @@ public class Program
             {
                 h.AdditionalNewLineAfterOption = false;
                 h.Heading = "trxml";
-                h.Copyright = "Copyright (c) 2023 Ken Domino"; //change copyright text
+                h.Copyright = "Copyright (c) 2026 Ken Domino"; //change copyright text
                 h.AddPreOptionsText(new Command().Help());
                 return HelpText.DefaultParsingErrorsHandler(result, h);
             }, e => e);

--- a/src/trxml/readme.md
+++ b/src/trxml/readme.md
@@ -24,7 +24,7 @@ Read a tree from stdin and write an XML represenation of it.
 
 The MIT License
 
-Copyright (c) 2025 Ken Domino
+Copyright (c) 2026 Ken Domino
 
 Permission is hereby granted, free of charge, 
 to any person obtaining a copy of this software and 

--- a/src/trxml2/Program.cs
+++ b/src/trxml2/Program.cs
@@ -35,7 +35,7 @@ class Program
             {
                 h.AdditionalNewLineAfterOption = false;
                 h.Heading = "trxml2";
-                h.Copyright = "Copyright (c) 2023 Ken Domino"; //change copyright text
+                h.Copyright = "Copyright (c) 2026 Ken Domino"; //change copyright text
                 h.AddPreOptionsText(new Command().Help());
                 return HelpText.DefaultParsingErrorsHandler(result, h);
             }, e => e);

--- a/src/trxml2/readme.md
+++ b/src/trxml2/readme.md
@@ -24,7 +24,7 @@ Read an xml file and enumerate all paths to elements in xpath syntax.
 
 The MIT License
 
-Copyright (c) 2025 Ken Domino
+Copyright (c) 2026 Ken Domino
 
 Permission is hereby granted, free of charge, 
 to any person obtaining a copy of this software and 

--- a/src/trxpath/Program.cs
+++ b/src/trxpath/Program.cs
@@ -35,7 +35,7 @@ public class Program
             {
                 h.AdditionalNewLineAfterOption = false;
                 h.Heading = "trxpath";
-                h.Copyright = "Copyright (c) 2023 Ken Domino"; //change copyright text
+                h.Copyright = "Copyright (c) 2026 Ken Domino"; //change copyright text
                 h.AddPreOptionsText(new Command().Help());
                 return HelpText.DefaultParsingErrorsHandler(result, h);
             }, e => e);

--- a/src/trxpath/readme.md
+++ b/src/trxpath/readme.md
@@ -30,7 +30,7 @@ XPaths, type _export MSYS2_ARG_CONV_EXCL="*"_, then execute your command.
 
 The MIT License
 
-Copyright (c) 2025 Ken Domino
+Copyright (c) 2026 Ken Domino
 
 Permission is hereby granted, free of charge, 
 to any person obtaining a copy of this software and 

--- a/src/trxquery/Program.cs
+++ b/src/trxquery/Program.cs
@@ -35,7 +35,7 @@ public class Program
             {
                 h.AdditionalNewLineAfterOption = false;
                 h.Heading = "trxquery";
-                h.Copyright = "Copyright (c) 2023 Ken Domino";
+                h.Copyright = "Copyright (c) 2026 Ken Domino";
                 h.AddPreOptionsText(new Command().Help());
                 return HelpText.DefaultParsingErrorsHandler(result, h);
             }, e => e);


### PR DESCRIPTION
## Summary
- Updated all Ken Domino copyright notices across 106 files to reflect 2026
- LICENSE files updated to year ranges (e.g., 2021-2026, 2017-2026)
- All Program.cs, readme.md, grammar, and source files updated

## Test plan
- [ ] Verify copyright strings display correctly in tool help output (`dotnet trash <subcommand> --help`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)