### PR TITLE
Fix readme corrections across all tools

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -153,15 +153,15 @@ creates an application using the Arithmetic grammar.
 If executed in a directory containing
 an Antlr Maven plugin (`pom.xml`), `dotnet trash gen` will create a program according
 to the information specified in the `pom.xml` file. Either way, it creates a directory
-`Generated/`, and places the source code there.
+`Generated-<target>/` (e.g. `Generated-CSharp/`), and places the source code there.
 
 `dotnet trash gen` has many options to generate a parser from any Antlr4 grammar, for any target.
 But, if a parser is generated for the C# target, built using the NET SDK, then `dotnet trash parse`
 can execute the generated parser, and can be used with all the other tools in Trash. _NB:
 In order to use the generated parser application, you must first build it:
 
-    dotnet restore Generated/Test.csproj
-    dotnet build Generated/Test.csproj
+    dotnet restore Generated-CSharp/Test.csproj
+    dotnet build Generated-CSharp/Test.csproj
 
 ### Run the generated parser application
 
@@ -169,7 +169,7 @@ In order to use the generated parser application, you must first build it:
 
 After using `dotnet trash gen` to generate a parser program in C#, shown previously,
 and after building the program, you can run the parser using `dotnet trash parse`. This program
-looks for the generated parser in directory `Generated/`. If it exists,
+looks for the generated parser in the `Generated-CSharp/` directory. If it exists,
 it will run the parser application in the directory. You can pass
 as command-line arguments an input string or input file. If no command-line
 arguments are supplied, the program will read stdin. The output of `dotnet trash parse`, as
@@ -177,7 +177,7 @@ with most tools of Trash, is parse tree data.
 
 ### Find nodes in the parse tree using XPath
 
-    mkdir empty; cd empty; dotnet trash gen; dotnet build Generated/Test.csproj; \
+    mkdir empty; cd empty; dotnet trash gen; dotnet build Generated-CSharp/Test.csproj; \
         dotnet trash parse -i "1+2+3" | dotnet trash query "grep //SCIENTIFIC_NUMBER"
 
 With this command, a directory is created, the Arithmetic grammar generated, built,
@@ -211,7 +211,7 @@ grammar symbols in any support source code (but it could if the tool is extended
 
     git clone https://github.com/antlr/grammars-v4.git; \
         cd grammars-v4/java/java9; \
-        dotnet trash gen; dotnet build Generated/Test.csproj;\
+        dotnet trash gen; dotnet build Generated-CSharp/Test.csproj;\
         dotnet trash parse examples/AllInOne8.java | dotnet trash query "grep //methodDeclaration" | dotnet trash text | wc
 
 This command clones the Antlr4 grammars-v4 repo, generates a parser for the Java9 grammar,

--- a/readme.md
+++ b/readme.md
@@ -64,6 +64,7 @@ grammar from spec. See [this script](https://github.com/kaby76/ScrapeDartSpec/bl
 1) <a href="src/trgenvsc/readme.md">dotnet trash genvsc</a> -- Generate VS Code extension files
 1) <a href="src/trglob/readme.md">dotnet trash glob</a> -- Glob file patterns
 1) <a href="src/triconv/readme.md">dotnet trash iconv</a> -- Convert file encoding
+1) <a href="src/trinterp/readme.md">dotnet trash interp</a> -- Generate ANTLR4 .interp files from a grammar parse tree
 1) <a href="src/tritext/readme.md">dotnet trash itext</a> -- Get strings from a PDF file
 1) <a href="src/trjson/readme.md">dotnet trash json</a> -- Print a parse tree in JSON structured format
 1) <a href="src/trnullable/readme.md">dotnet trash nullable</a> -- Nullable analysis of a grammar
@@ -84,6 +85,7 @@ grammar from spec. See [this script](https://github.com/kaby76/ScrapeDartSpec/bl
 1) <a href="src/trxpath/readme.md">dotnet trash xpath</a> -- Search using XPath in parse trees
 1) <a href="src/trxml/readme.md">dotnet trash xml</a> -- Print a parse tree in XML structured format
 1) <a href="src/trxml2/readme.md">dotnet trash xml2</a> -- Print an enumeration of all paths in a parse tree to leaves
+1) <a href="src/trxquery/readme.md">dotnet trash xquery</a> -- Apply XQuery Update expressions to a parse tree
 
 ## Examples
 
@@ -117,29 +119,27 @@ EOF
 ```
 dotnet trash parse -i "a == b" | dotnet trash tree
 ```
-`trtree` is only one of several ways to view parse tree data.
-Other programs for different output are
-[trjson](https://github.com/kaby76/Trash/tree/main/src/trjson) for [JSON output](https://github.com/kaby76/Trash/blob/main/_tests/trconvert/antlr2/ada.g4.json),
-[trxml](https://github.com/kaby76/Trash/tree/main/src/trxml) for [XML output](https://github.com/kaby76/Trash/blob/main/_tests/trconvert/antlr2/ada.g4.xml),
-[trst](https://github.com/kaby76/Trash/tree/main/src/trst) for [Antlr runtime ToStringTree output](https://github.com/kaby76/Trash/blob/main/_tests/trconvert/antlr2/ada.g4.st),
-[trdot](https://github.com/kaby76/Trash/tree/main/src/trdot),
-[trprint](https://github.com/kaby76/Trash/tree/main/src/trprint) for input text for the parse,
+`dotnet trash tree` is only one of several ways to view parse tree data.
+Other commands for different output are
+[dotnet trash json](https://github.com/kaby76/Trash/tree/main/src/trjson) for [JSON output](https://github.com/kaby76/Trash/blob/main/_tests/trconvert/antlr2/ada.g4.json),
+[dotnet trash xml](https://github.com/kaby76/Trash/tree/main/src/trxml) for [XML output](https://github.com/kaby76/Trash/blob/main/_tests/trconvert/antlr2/ada.g4.xml),
+[dotnet trash dot](https://github.com/kaby76/Trash/tree/main/src/trdot) for Graphviz Dot output,
 and
-[tragl](https://github.com/kaby76/Trash/tree/main/src/tragl).
+[dotnet trash text](https://github.com/kaby76/Trash/tree/main/src/trtext) for the source text of a parse tree interval.
 
 ### Convert grammars to Antlr4
 ```
-dotnet trash parse ada.g2 | dotnet trash convert | trprint | less
+dotnet trash parse ada.g2 | dotnet trash convert | dotnet trash text | less
 ```
 This command parses an [old Antlr2 grammar](https://github.com/kaby76/Trash/blob/main/_tests/trconvert/antlr2/ada.g2)
-using [trparse](https://github.com/kaby76/Trash/tree/main/src/trparse),
+using [dotnet trash parse](https://github.com/kaby76/Trash/tree/main/src/trparse),
 converts the parse tree data to Antlr4 syntax using
- [trconvert](https://github.com/kaby76/Trash/tree/main/src/trconvert)
- and
+[dotnet trash convert](https://github.com/kaby76/Trash/tree/main/src/trconvert)
+and
 finally [prints out the converted parse tree data, ada.g4](https://github.com/kaby76/Trash/blob/main/_tests/trconvert/antlr2/ada.g4)
 using
-[trprint](https://github.com/kaby76/Trash/tree/main/src/trprint). Other
-grammar that can be converted are Antlr3, Bison, and ISO EBNF. In order to
+[dotnet trash text](https://github.com/kaby76/Trash/tree/main/src/trtext). Other
+grammars that can be converted are Antlr3, Bison, and ISO EBNF. In order to
 use the grammar to parse data, you will need to convert it to an Antlr4 grammar.
 
 ### Generate an Arithmetic parser application
@@ -148,44 +148,44 @@ mkdir foobar; cd foobar; dotnet trash gen
 ```
 This command creates a parser application for the C# target.
 If executed in an empty directory, which is done in the example
-shown above, [trgen](https://github.com/kaby76/Trash/tree/main/src/trgen)
+shown above, [dotnet trash gen](https://github.com/kaby76/Trash/tree/main/src/trgen)
 creates an application using the Arithmetic grammar.
 If executed in a directory containing
-a Antlr Maven plugin (`pom.xml`), `trgen` will create a program according
+an Antlr Maven plugin (`pom.xml`), `dotnet trash gen` will create a program according
 to the information specified in the `pom.xml` file. Either way, it creates a directory
 `Generated/`, and places the source code there.
 
-`trgen` has many options to generate a parser from any Antlr4 grammar, for any target.
-But, if a parser is generated for the C# target, built using the NET SDK, then `trparse`
+`dotnet trash gen` has many options to generate a parser from any Antlr4 grammar, for any target.
+But, if a parser is generated for the C# target, built using the NET SDK, then `dotnet trash parse`
 can execute the generated parser, and can be used with all the other tools in Trash. _NB:
-In order to use the generate parser application, you must first build it:
+In order to use the generated parser application, you must first build it:
 
     dotnet restore Generated/Test.csproj
     dotnet build Generated/Test.csproj
 
 ### Run the generated parser application
 
-    trash parse -i "1+2+3" | trash tree
+    dotnet trash parse -i "1+2+3" | dotnet trash tree
 
-After using `trgen` to generate a parser program in C#, shown previously,
-and after building the program, you can run the parser using `trparse`. This program 
+After using `dotnet trash gen` to generate a parser program in C#, shown previously,
+and after building the program, you can run the parser using `dotnet trash parse`. This program
 looks for the generated parser in directory `Generated/`. If it exists,
 it will run the parser application in the directory. You can pass
 as command-line arguments an input string or input file. If no command-line
-arguments are supplied, the program will read stdin. The output of `trparse`, as
+arguments are supplied, the program will read stdin. The output of `dotnet trash parse`, as
 with most tools of Trash, is parse tree data.
 
 ### Find nodes in the parse tree using XPath
 
-    mkdir empty; cd empty; trash gen; dotnet build Generated/Test.csproj; \
-        trash parse -i "1+2+3" | trash query "grep //SCIENTIFIC_NUMBER"
+    mkdir empty; cd empty; dotnet trash gen; dotnet build Generated/Test.csproj; \
+        dotnet trash parse -i "1+2+3" | dotnet trash query "grep //SCIENTIFIC_NUMBER"
 
-With this command, a directory is created, the Arithmetic grammar generated, build,
-and then run using [parse](https://github.com/kaby76/Trash/tree/main/src/trparse).
-The `trash parse` tool unifies all parsing, whether it's parsing a grammar or parsing input
-using a generated parser application. The output from the `trparse` tool is a parse
-tree which you can search. [query](https://github.com/kaby76/Trash/tree/main/src/trquery)
-is the generalized search program for parse trees. `Trquery` uses XPath expressions to
+With this command, a directory is created, the Arithmetic grammar generated, built,
+and then run using [dotnet trash parse](https://github.com/kaby76/Trash/tree/main/src/trparse).
+The `dotnet trash parse` tool unifies all parsing, whether it's parsing a grammar or parsing input
+using a generated parser application. The output from `dotnet trash parse` is a parse
+tree which you can search. [dotnet trash query](https://github.com/kaby76/Trash/tree/main/src/trquery)
+is the generalized search program for parse trees. `dotnet trash query` uses XPath expressions to
 precisely identify nodes in the parse tree.
 
 XPath was added to Antlr4, but `Trash` takes the idea
@@ -196,33 +196,29 @@ used more often in compiler construction.
 
 ### Rename a symbol in a grammar, generate a parser for new grammar
 
-    trash parse Arithmetic.g4 | trash rename "//parserRuleSpec//labeledAlt//RULE_REF[text() = 'expression']" "xxx" | dotnet trash text > new-source.g4
-    trash parse Arithmetic.g4 | trash rename -r "expression,expression_;atom,atom_;scientific,scientific_" | trprint
+    dotnet trash parse Arithmetic.g4 | dotnet trash rename "//parserRuleSpec//labeledAlt//RULE_REF[text() = 'expression']" "xxx" | dotnet trash text > new-source.g4
+    dotnet trash parse Arithmetic.g4 | dotnet trash rename -r "expression,expression_;atom,atom_;scientific,scientific_" | dotnet trash text
 
 In these two examples, the Arithmetic grammar is parsed.
-[trrename](https://github.com/kaby76/Trash/tree/main/src/trrename) reads the parse tree data and
+[dotnet trash rename](https://github.com/kaby76/Trash/tree/main/src/trrename) reads the parse tree data and
 modifies it by renaming the `expression` symbol two ways: first by XPath expression identifying the LHS terminal
 symbol of the `expression` symbol, and the second by assumption that the tree is an Antlr4 parse tree,
 then renaming a semi-colon-separated list of paired renames. The resulting code is reconstructed and saved.
-`trrename` does not rename symbols in actions, nor does it rename identifiers corresponding to the
+`dotnet trash rename` does not rename symbols in actions, nor does it rename identifiers corresponding to the
 grammar symbols in any support source code (but it could if the tool is extended).
 
 ### Count method declarations in a Java source file
 
     git clone https://github.com/antlr/grammars-v4.git; \
         cd grammars-v4/java/java9; \
-        trash gen; dotnet build Generated/Test.csproj;\
-        trash parse examples/AllInOne8.java | trash query "greap //methodDeclaration" | trst | wc
+        dotnet trash gen; dotnet build Generated/Test.csproj;\
+        dotnet trash parse examples/AllInOne8.java | dotnet trash query "grep //methodDeclaration" | dotnet trash text | wc
 
 This command clones the Antlr4 grammars-v4 repo, generates a parser for the Java9 grammar,
 then runs the parser on [examples/AllInOne8.java](https://github.com/antlr/grammars-v4/blob/master/java/java9/examples/AllInOne8.java).
-The parse tree is then piped to `trquery` to find all parse tree nodes that are
-a `methodDeclaration` type, converts it to a simple string, and counts the result using
+The parse tree is then piped to `dotnet trash query` to find all parse tree nodes that are
+a `methodDeclaration` type, prints the source text of each, and counts the result using
 `wc`.
-
-### Strip a grammar of all non-essential CFG
-
-    trash parse Java9.g4 | trash strip | trash text > Essential-Java9.g4
 
 ### Split a grammar
 
@@ -233,9 +229,9 @@ a grammar, it's tedious. For automating transformations, it's
 necessary because Antlr4 requires the grammars to be split
 when super classes are needed for different targets.
 
-    trash combine ArithmeticLexer.g4 ArithmeticParser.g4 | trash text > Arithmetic.g4
+    dotnet trash combine ArithmeticLexer.g4 ArithmeticParser.g4 | dotnet trash text > Arithmetic.g4
 
-This command calls [trcombine](https://github.com/kaby76/Trash/tree/main/src/trcombine)
+This command calls [dotnet trash combine](https://github.com/kaby76/Trash/tree/main/src/trcombine)
 which parses two split grammar files
 [ArithmeticLexer.g4](https://github.com/kaby76/Trash/blob/main/_tests/combine/ArithmeticLexer.g4)
 and
@@ -243,12 +239,12 @@ and
 and creates a [combined grammar](https://github.com/kaby76/Trash/blob/main/_tests/combine/Arithmetic.g4)
 for the two.
 
-    trash parse Arithmetic.g4 | trash split | trash sponge -o true
+    dotnet trash parse Arithmetic.g4 | dotnet trash split | dotnet trash sponge
 
-This command calls [trsplit](https://github.com/kaby76/Trash/tree/main/src/trsplit)
+This command calls [dotnet trash split](https://github.com/kaby76/Trash/tree/main/src/trsplit)
 which splits the grammar into two parse tree results, one that defines
 ArithmeticLexer.g4 and the other that defines ArithmeticParser.g4.
-The tool [trsponge](https://github.com/kaby76/Trash/tree/main/src/trsponge)
+The tool [dotnet trash sponge](https://github.com/kaby76/Trash/tree/main/src/trsponge)
 is similar to the [tee](https://en.wikipedia.org/wiki/Tee_(command)) in
 Linux: the parse tree data is split and placed in files.
 

--- a/src/tragl/readme.md
+++ b/src/tragl/readme.md
@@ -11,11 +11,11 @@ This tool is part of Trash, Transformations for Antlr Shell.
 
 ## Usage
 
-    tragl
+    dotnet trash agl
 
 ## Example
 
-    trparse -i "1+2" | tragl
+    dotnet trash parse -i "1+2" | dotnet trash agl
 
 ## Current version
 

--- a/src/tranalyze/readme.md
+++ b/src/tranalyze/readme.md
@@ -11,7 +11,7 @@ searches for problems in the grammar, and outputs the results to stdout.
 
 ## Usage
 
-    tranalyze
+    dotnet trash analyze
 
 ## Details
 
@@ -45,7 +45,7 @@ _Input to command_
 
 _Command_
 
-    trparse Test.g4 | tranalyze
+    dotnet trash parse Test.g4 | dotnet trash analyze
 
 _Output_
 

--- a/src/trash/readme.md
+++ b/src/trash/readme.md
@@ -49,6 +49,7 @@ Both the full command name and a short alias (without the `tr` prefix) are accep
 | trgenvsc       | genvsc      |
 | trglob         | glob        |
 | triconv        | iconv       |
+| trinterp       | interp      |
 | tritext        | itext       |
 | trjson         | json        |
 | trnullable     | nullable    |
@@ -69,5 +70,6 @@ Both the full command name and a short alias (without the `tr` prefix) are accep
 | trxpath        | xpath       |
 | trxml          | xml         |
 | trxml2         | xml2        |
+| trxquery       | xquery      |
 
 Run `trash --help` to list all commands. Run `trash <command> --help` for per-command help.

--- a/src/trcaret/readme.md
+++ b/src/trcaret/readme.md
@@ -10,11 +10,11 @@ Reads a tree from stdin and prints lines and caret marks.
 
 ## Usage
 
-    trcaret [options]
+    dotnet trash caret [options]
 
 ## Examples
 
-    trquery grep //lexerRuleSpec | trcaret -H
+    dotnet trash query "grep //lexerRuleSpec" | dotnet trash caret -H
 
 ## Current version
 

--- a/src/trcombine/readme.md
+++ b/src/trcombine/readme.md
@@ -12,7 +12,7 @@ order is irrelevant. The output is parse tree data.
 
 ## Usage
 
-    trcombine <grammar1> <grammar2>
+    dotnet trash combine <grammar1> <grammar2>
 
 ## Details
 
@@ -74,7 +74,7 @@ Parser grammar in ExpressionParser.g4:
 
 _Command_
 
-    trcombine ExpressionLexer.g4 ExpressionParser.g4 | trprint > Expression.g4
+    dotnet trash combine ExpressionLexer.g4 ExpressionParser.g4 | dotnet trash text > Expression.g4
 
 Combined grammar in Expression.g4:
 

--- a/src/trconvert/readme.md
+++ b/src/trconvert/readme.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-Convert a grammar from one for to another
+Convert a grammar from one form to another
 
 ## Description
 
@@ -12,7 +12,7 @@ Bison, W3C EBNF, Lark). The input and output are Parse Tree Data.
 
 ## Usage
 
-    trconvert [-t <type>]
+    dotnet trash convert [-t <type>]
 
 ## Details
 
@@ -59,7 +59,7 @@ _Conversion of Antlr4 Abnf to Lark Abnf_
 
 _Command_
 
-    trparse Abnf.g4 | trconvert -t lark | trprint > Abnf.lark
+    dotnet trash parse Abnf.g4 | dotnet trash convert -t lark | dotnet trash text > Abnf.lark
 
 _Output_
 

--- a/src/trdistill/readme.md
+++ b/src/trdistill/readme.md
@@ -1,95 +1,16 @@
-# trconvert
+# trdistill
 
 ## Summary
 
-Convert a grammar from one for to another
+Distill a grammar (currently under development)
 
 ## Description
 
-Reads a grammar from stdin and converts the grammar to/from Antlr version 4
-syntax. The original grammar must be for a supported type (Antlr2, Antlr3,
-Bison, W3C EBNF, Lark). The input and output are Parse Tree Data.
-
 ## Usage
-
-    trconvert [-t <type>]
 
 ## Details
 
-This command converts a grammar from one type to another. Most
-conversions will handle only simple syntax differences. More complicated
-scenarios are supported depending on the source and target grammar types.
-For example, Bison is converted to Antlr4, but the reverse is not
-implemented yet.
-
-`trconvert` takes an option target type. If it is not used, the default
-is to convert the input of whatever type to Antlr4 syntax. The output
-of `trconvert` is a parse tree containing the converted grammar.
-
 ## Examples
-
-_Conversion of Antlr4 Abnf to Lark Abnf_
-
-    grammar Abnf;
-
-    rulelist : rule_* EOF ;
-    rule_ : ID '=' '/'? elements ;
-    elements : alternation ;
-    alternation : concatenation ( '/' concatenation )* ;
-    concatenation : repetition + ;
-    repetition : repeat_? element ;
-    repeat_ : INT | ( INT? '*' INT? ) ;
-    element : ID | group | option | STRING | NumberValue | ProseValue ;
-    group : '(' alternation ')' ;
-    option : '[' alternation ']' ;
-    NumberValue : '%' ( BinaryValue | DecimalValue | HexValue ) ;
-    fragment BinaryValue : 'b' BIT+ ( ( '.' BIT+ )+ | ( '-' BIT+ ) )? ;
-    fragment DecimalValue : 'd' DIGIT+ ( ( '.' DIGIT+ )+ | ( '-' DIGIT+ ) )? ;
-    fragment HexValue : 'x' HEX_DIGIT+ ( ( '.' HEX_DIGIT+ )+ | ( '-' HEX_DIGIT+ ) )? ;
-    ProseValue : '<' ( ~ '>' )* '>' ;
-    ID : LETTER ( LETTER | DIGIT | '-' )* ;
-    INT : '0' .. '9'+ ;
-    COMMENT : ';' ~ ( '\n' | '\r' )* '\r'? '\n' -> channel ( HIDDEN ) ;
-    WS : ( ' ' | '\t' | '\r' | '\n' ) -> channel ( HIDDEN ) ;
-    STRING : ( '%s' | '%i' )? '"' ( ~ '"' )* '"' ;
-    fragment LETTER : 'a' .. 'z' | 'A' .. 'Z' ;
-    fragment BIT : '0' .. '1' ;
-    fragment DIGIT : '0' .. '9' ;
-    fragment HEX_DIGIT : ( '0' .. '9' | 'a' .. 'f' | 'A' .. 'F' ) ;
-
-_Command_
-
-    trparse Abnf.g4 | trconvert -t lark | trprint > Abnf.lark
-
-_Output_
-
-    rulelist :  rule_ * EOF 
-    rule_ :  ID "=" "/" ? elements 
-    elements :  alternation 
-    alternation :  concatenation ( "/" concatenation ) * 
-    concatenation :  repetition + 
-    repetition :  repeat_ ? element 
-    repeat_ :  INT | ( INT ? "*" INT ? ) 
-    element :  ID | group | option | STRING | NUMBERVALUE | PROSEVALUE 
-    group :  "(" alternation ")" 
-    option :  "[" alternation "]" 
-    NUMBERVALUE :  "%" ( BINARYVALUE | DECIMALVALUE | HEXVALUE ) 
-    BINARYVALUE :  "b" BIT + ( ( "." BIT + ) + | ( "-" BIT + ) ) ? 
-    DECIMALVALUE :  "d" DIGIT + ( ( "." DIGIT + ) + | ( "-" DIGIT + ) ) ? 
-    HEXVALUE :  "x" HEX_DIGIT + ( ( "." HEX_DIGIT + ) + | ( "-" HEX_DIGIT + ) ) ? 
-    PROSEVALUE :  "<" ( /(?!>)/ ) * ">" 
-    ID :  LETTER ( LETTER | DIGIT | "-" ) * 
-    INT :  "0" .. "9" + 
-    COMMENT :  ";" /(?!\n|\r)/ * "\r" ? "\n" 
-    WS :  ( " " | "\t" | "\r" | "\n" ) 
-    STRING :  ( "%s" | "%i" ) ? "\"" ( /(?!")/ ) * "\"" 
-    LETTER :  "a" .. "z" | "A" .. "Z" 
-    BIT :  "0" .. "1" 
-    DIGIT :  "0" .. "9" 
-    HEX_DIGIT :  ( "0" .. "9" | "a" .. "f" | "A" .. "F" ) 
-
-    %ignore COMMENT
-    %ignore WS
 
 ## Current version
 
@@ -101,23 +22,23 @@ The MIT License
 
 Copyright (c) 2025 Ken Domino
 
-Permission is hereby granted, free of charge, 
-to any person obtaining a copy of this software and 
-associated documentation files (the "Software"), to 
-deal in the Software without restriction, including 
-without limitation the rights to use, copy, modify, 
-merge, publish, distribute, sublicense, and/or sell 
-copies of the Software, and to permit persons to whom 
-the Software is furnished to do so, 
+Permission is hereby granted, free of charge,
+to any person obtaining a copy of this software and
+associated documentation files (the "Software"), to
+deal in the Software without restriction, including
+without limitation the rights to use, copy, modify,
+merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom
+the Software is furnished to do so,
 subject to the following conditions:
 
-The above copyright notice and this permission notice 
+The above copyright notice and this permission notice
 shall be included in all copies or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, 
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES 
-OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. 
-IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR 
-ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, 
-TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE 
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR
+ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/src/trdot/readme.md
+++ b/src/trdot/readme.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-Print a parse tree in Graphvis Dot format
+Print a parse tree in Graphviz Dot format
 
 ## Description
 
@@ -10,7 +10,7 @@ Reads a tree from stdin and prints the tree as a Dot graph.
 
 ## Usage
 
-    trdot
+    dotnet trash dot
 
 ## Details
 
@@ -27,11 +27,11 @@ or a list of parse tree nodes obtained via
 
 Consider the Expression grammar, obtained via
 
-    mkdir foo; cd foo; trgen; cd Generated; dotnet build
+    mkdir foo; cd foo; dotnet trash gen; cd Generated-CSharp; dotnet build
 
 Let's parse the expression "1+2" and print the parse tree as a Dot graph:
 
-    trparse -i "1+2" | trdot
+    dotnet trash parse -i "1+2" | dotnet trash dot
 
 The output will be:
 

--- a/src/trextract/readme.md
+++ b/src/trextract/readme.md
@@ -27,7 +27,7 @@ _Input to command_
 
 _Command_
 
-dotnet trash parse ExpressionLexer.g4 ExpressionParser.g4 | dotnet trash extract | dotnet trash sponge -c
+    dotnet trash parse ExpressionLexer.g4 ExpressionParser.g4 | dotnet trash extract | dotnet trash sponge -c
 
 The outputed files are:
 

--- a/src/trextract/readme.md
+++ b/src/trextract/readme.md
@@ -15,7 +15,7 @@ grammars into completely target independent grammars.
 
 ## Usage
 
-trparse *.g4 | trextract | trsponge -c
+    dotnet trash parse *.g4 | dotnet trash extract | dotnet trash sponge -c
 
 ## Details
 
@@ -27,7 +27,7 @@ _Input to command_
 
 _Command_
 
-trparse ExpressionLexer.g4 ExpressionParser.g4 | trextract | trsponge -c
+dotnet trash parse ExpressionLexer.g4 ExpressionParser.g4 | dotnet trash extract | dotnet trash sponge -c
 
 The outputed files are:
 

--- a/src/trff/readme.md
+++ b/src/trff/readme.md
@@ -8,7 +8,7 @@ Outputs FIRST and FOLLOW sets of a grammar.
 
 ## Usage
 
-trff (assumes CSharp-targeted parser generated and compiled)
+    dotnet trash ff
 
 ## Details
 

--- a/src/trfold/readme.md
+++ b/src/trfold/readme.md
@@ -12,11 +12,11 @@ to stdout. The input and output are Parse Tree Data.
 
 ## Usage
 
-    trfold <string>
+    dotnet trash fold <string>
 
 ## Example
 
-    trparse A.g4 | trfold "//parserRuleSpec[RULE_REF/text() = 'normalAnnotation']"
+    dotnet trash parse A.g4 | dotnet trash fold "//parserRuleSpec[RULE_REF/text() = 'normalAnnotation']"
 
 ## Notes
 

--- a/src/trfoldlit/readme.md
+++ b/src/trfoldlit/readme.md
@@ -13,7 +13,7 @@ output are Parse Tree Data.
 
 ## Usage
 
-    trfoldlit
+    dotnet trash foldlit
 
 ## Examples
 
@@ -37,7 +37,7 @@ Before:
 
 Command:
 
-    trparse Expression.g4 | trfoldlit | trsponge -c
+    dotnet trash parse Expression.g4 | dotnet trash foldlit | dotnet trash sponge -c
 
 After:
 

--- a/src/trformat/readme.md
+++ b/src/trformat/readme.md
@@ -10,11 +10,11 @@ Format of grammar using machine learning.
 
 ## Usage
 
-    trformat
+    dotnet trash format
 
 ## Examples
 
-    trparse A.g4 | trformat
+    dotnet trash parse A.g4 | dotnet trash format
 
 ## Current version
 

--- a/src/trgen/readme.md
+++ b/src/trgen/readme.md
@@ -15,11 +15,11 @@ create a parser for the Arithmetic.g4 grammar.
 
 ## Usage
 
-    trgen <options>* 
+    dotnet trash gen <options>*
 
 ## Examples
 
-    trgen
+    dotnet trash gen
 
 ## Specification of desc.xml ([schema](https://github.com/kaby76/Trash/blob/main/desc.xsd))
 
@@ -37,7 +37,7 @@ A typical desc.xml simply specifies all targets to test.
    <targets>Antlr4cs;Antlr4ng;Cpp;CSharp;Dart;Go;Java;JavaScript;PHP;Python3;TypeScript</targets>
 </desc>
 ```
-trgen will read all .g4's contained in the directory with the desc.xml file.
+`dotnet trash gen` will read all .g4's contained in the directory with the desc.xml file.
 It computes a dependency graph of the grammars used via `tokenVocab` options,
 and `import` statements. The tool will then perform a topological sort, determine
 the first "top-level" parser or combined grammar, and use that grammar for testing.

--- a/src/trgenvsc/readme.md
+++ b/src/trgenvsc/readme.md
@@ -22,11 +22,11 @@ the XPath patterns to match certain parse trees.
 
 ## Usage
 
-    trgenvsc <options>* 
+    dotnet trash genvsc <options>*
 
 ## Examples
 
-    trgenvsc
+    dotnet trash genvsc
 
 ## Current version
 

--- a/src/trglob/readme.md
+++ b/src/trglob/readme.md
@@ -8,12 +8,12 @@ Expand a glob string into file names.
 
 ## Usage
 
-    trgen <string>+
+    dotnet trash glob <string>+
 
 ## Examples
 
-    trglob '../examples/**/*.dart'
-    trglob '../examples/**'
+    dotnet trash glob '../examples/**/*.dart'
+    dotnet trash glob '../examples/**'
 
 ## Current version
 

--- a/src/trgroup/readme.md
+++ b/src/trgroup/readme.md
@@ -10,7 +10,7 @@ Perform a recursive left- and right- factorization of alternatives for rules.
 
 ## Usage
 
-    trgroup <string>
+    dotnet trash group <string>
 
 ## Details
 
@@ -37,11 +37,11 @@ _Input to command (file "temp.g4")_
 
 _Command_
 
-    trparse temp.g4 | trgroup "//parserRuleSpec[RULE_REF/text()='a']//ruleAltList" | trsponge -c true
-    
+    dotnet trash parse temp.g4 | dotnet trash group "//parserRuleSpec[RULE_REF/text()='a']//ruleAltList" | dotnet trash sponge -c
+
     # Or, a file-wide group refactoring, over all parser and lexer rules:
-    
-    trparse temp.g4 | trgroup | trsponge -c true
+
+    dotnet trash parse temp.g4 | dotnet trash group | dotnet trash sponge -c
 
 _Output_
 

--- a/src/triconv/readme.md
+++ b/src/triconv/readme.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-Test whether a file is proper Unicode.
+Convert file encoding.
 
 ## Description
 
@@ -11,11 +11,11 @@ unicode.
 
 ## Usage
 
-    triconv [-f ENCODING] [-t ENCODING] [INPUTFILE...]
+    dotnet trash iconv [--from-code ENCODING] [--to-code ENCODING] [INPUTFILE...]
 
 ## Examples
 
-    triconf -f utf-8 file.txt > /dev/null
+    dotnet trash iconv --from-code utf-8 file.txt > /dev/null
     echo $?
 
 ## Current version
@@ -28,23 +28,23 @@ The MIT License
 
 Copyright (c) 2025 Ken Domino
 
-Permission is hereby granted, free of charge, 
-to any person obtaining a copy of this software and 
-associated documentation files (the "Software"), to 
-deal in the Software without restriction, including 
-without limitation the rights to use, copy, modify, 
-merge, publish, distribute, sublicense, and/or sell 
-copies of the Software, and to permit persons to whom 
-the Software is furnished to do so, 
+Permission is hereby granted, free of charge,
+to any person obtaining a copy of this software and
+associated documentation files (the "Software"), to
+deal in the Software without restriction, including
+without limitation the rights to use, copy, modify,
+merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom
+the Software is furnished to do so,
 subject to the following conditions:
 
-The above copyright notice and this permission notice 
+The above copyright notice and this permission notice
 shall be included in all copies or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, 
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES 
-OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. 
-IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR 
-ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, 
-TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE 
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR
+ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/src/trjson/readme.md
+++ b/src/trjson/readme.md
@@ -10,11 +10,11 @@ Read a parse tree from stdin and write a JSON represenation of it.
 
 ## Usage
 
-    trjson
+    dotnet trash json
 
 ## Examples
 
-    trparse A.g4 | trjson | less
+    dotnet trash parse A.g4 | dotnet trash json | less
 
 ## Current version
 

--- a/src/trkleene/readme.md
+++ b/src/trkleene/readme.md
@@ -10,7 +10,7 @@ Replace a rule with an EBNF form if it contains direct left or direct right recu
 
 ## Usage
 
-trkleene <string>?
+    dotnet trash kleene <string>?
 
 ## Details
 
@@ -27,8 +27,8 @@ is outputed to stdout.
 
 ## Examples
 
-    trparse A.g4 | trkleene
-    trparse A.g4 | trkleene "//parserRuleSpec/RULE_REF[text()='packageOrTypeName']"
+    dotnet trash parse A.g4 | dotnet trash kleene
+    dotnet trash parse A.g4 | dotnet trash kleene "//parserRuleSpec/RULE_REF[text()='packageOrTypeName']"
 
 ## Notes
 

--- a/src/trnullable/readme.md
+++ b/src/trnullable/readme.md
@@ -10,11 +10,11 @@ Reads a parsing result set for a grammar and outputs the rules that are nullable
 
 ## Usage
 
-trnullable
+    dotnet trash nullable
 
 ## Examples
 
-trparse A.g4 | trnullable
+    dotnet trash parse A.g4 | dotnet trash nullable
 
 ## Current version
 

--- a/src/trparse/readme.md
+++ b/src/trparse/readme.md
@@ -25,9 +25,9 @@ depending on the extension of the file name:
 You can force the type of parse with
 the `--type` command-line option:
 
-* `ANTLRv4` for ANTLRv2
+* `ANTLRv4` for ANTLRv4
 * `ANTLRv3` for ANTLRv3
-* `ANTLRv2` for ANTLRv4
+* `ANTLRv2` for ANTLRv2
 * `Bison` for Bison
 * `rex` for Rex
 * `pegen_v3_10` for the `Generated/` parser
@@ -64,25 +64,24 @@ works without modification.
 
 ## Usage
 
-    trparse (<string> | <options>)*
+    dotnet trash parse (<string> | <options>)*
     -i, --input        Parse the given string as input.
     -t, --type         Specifies type of grammar: ANTLRv4, ANTLRv3, ANTLRv2, Bison, rex, pegen_v3_10
-    -s, --start-rule   Start rule name.
     -p, --parser       Location of pre-built parser (aka the trgen Generated/ directory)
         --pinterp      Path to parser .interp file (Earley ATN-based parsing).
         --linterp      Path to lexer .interp file  (Earley ATN-based parsing).
 
 ## Examples
 
-    trparse Java.g2
-    trparse -i "1+2+3"
-    trparse Foobar.g -t ANTLRv2
-    echo "1+2+3" | trparse | trtree
-    mkdir out; trparse MyParser.g4 MyLexer.g4 | trkleene | trsponge -o out
+    dotnet trash parse Java.g2
+    dotnet trash parse -i "1+2+3"
+    dotnet trash parse Foobar.g -t ANTLRv2
+    echo "1+2+3" | dotnet trash parse | dotnet trash tree
+    mkdir out; dotnet trash parse MyParser.g4 MyLexer.g4 | dotnet trash sponge -o out
 
     # Earley interp-based parse (no generated code needed)
     dotnet trash parse abb.g4 | dotnet trash interp -o out/
-    dotnet trash parse --pinterp out/abbParser.interp --linterp out/abbLexer.interp input.abb | trtree
+    dotnet trash parse --pinterp out/abbParser.interp --linterp out/abbLexer.interp input.abb | dotnet trash tree
 
 ## Current version
 

--- a/src/trperf/readme.md
+++ b/src/trperf/readme.md
@@ -14,9 +14,9 @@ are supported. To specify the grammar, you can either
 be in a trgen-generated parser directory, or use the -p option.
 
 ## Usage
-    
-    trperf (<string> | <options>)*
-    -c. -column      String of characters denoting columnns.
+
+    dotnet trash perf (<string> | <options>)*
+    -c, --columns    String of characters denoting columns.
                      F = File name
                      d = Decision number
                      r = Rule name
@@ -37,14 +37,14 @@ be in a trgen-generated parser directory, or use the -p option.
 ## Examples
 
     # print out performance data for a parse, ignore the header line, sort on "Max k", and output in a formatted table.
-    trperf aggregate01.sql | tail -n +2 | sort -k6 -g -r | column -t
+    dotnet trash perf aggregate01.sql | tail -n +2 | sort -k6 -g -r | column -t
 
     # print out performance with header, sorting on ambiguity.
-    trperf x.go -h -c aFdriTkmfaet | ( head -n 1 && tail -n +2 | sort -k1 -g -r ) | head | column -t
+    dotnet trash perf x.go -h -c aFdriTkmfaet | ( head -n 1 && tail -n +2 | sort -k1 -g -r ) | head | column -t
 
     # print out performance with header, sorting on ambiguity,
     # compress text column.
-    dotnet trperf ../examples/AllInOneNoPreprocessor.cs -h -c aFdriTkmfaetc \
+    dotnet trash perf ../examples/AllInOneNoPreprocessor.cs -h -c aFdriTkmfaetc \
       | ( head -n 1 && tail -n +2 | sort -k1 -g -r ) \
       | head | awk '
       {

--- a/src/trpiggy/readme.md
+++ b/src/trpiggy/readme.md
@@ -14,7 +14,7 @@ that defines children.
 
 ## Usage
 
-    trpiggy template-spec
+    dotnet trash piggy template-spec
 
 ## Examples
 
@@ -54,7 +54,7 @@ Template input "templates.txt":
 //field[position()=1] -> {{ "<NAME>" : <exp> }} ;
 ```
 
-    trparse input.txt  | trpiggy templates.txt | trprint
+    dotnet trash parse input.txt | dotnet trash piggy templates.txt | dotnet trash text
 
 Output:
 ```

--- a/src/trquery/readme.md
+++ b/src/trquery/readme.md
@@ -14,6 +14,7 @@ to stdout. The input and output are Parse Tree Data.
 ## Usage
 
     dotnet trash query <command> [; additional commands...]*
+    dotnet trash query -c <commands-file>
 
 ## Details
 
@@ -28,12 +29,12 @@ each operation as with trinsert, trdelete, or trreplace.
 
 ### Commands
 
-grep <xpath> match-required?
-insert (before|after)? <xpath> match-required? <string>
-delete <xpath> match-required?
-delete-reattach <xpath> match-required?
-replace <xpath> match-required <string>
-move (before|after)? <xpath> match-required? <xpath>
+    grep <xpath> match-required?
+    insert (before|after)? <xpath> match-required? <string>
+    delete <xpath> match-required?
+    delete-reattach <xpath> match-required?
+    replace <xpath> match-required <string>
+    move (before|after)? <xpath> match-required? <xpath>
 
 ## Examples
 

--- a/src/trquery/readme.md
+++ b/src/trquery/readme.md
@@ -13,9 +13,7 @@ to stdout. The input and output are Parse Tree Data.
 
 ## Usage
 
-trquery insert xpath-expr string (; additional commands...)*
-trquery delete xpath-expr (; additional commands...)*
-trquery replace xpath-expr string (; additional commands...)*
+    dotnet trash query <command> [; additional commands...]*
 
 ## Details
 

--- a/src/trrename/readme.md
+++ b/src/trrename/readme.md
@@ -10,7 +10,7 @@ Rename symbols in a grammar.
 
 ## Usage
 
-    trrename -r <string>
+    dotnet trash rename -r <string>
 
 ## Details
 
@@ -23,7 +23,7 @@ make sure to enclose the argument as it contains semi-colons.
 
 ## Examples
 
-    trparse Foobar.g4 | trrename -r "a,b;c,d" | trprint > new-grammar.g4
+    dotnet trash parse Foobar.g4 | dotnet trash rename -r "a,b;c,d" | dotnet trash text > new-grammar.g4
 
 ## Current version
 

--- a/src/trrup/readme.md
+++ b/src/trrup/readme.md
@@ -10,7 +10,7 @@ Remove useless parentheses from a grammar.
 
 ## Usage
 
-    trrup
+    dotnet trash rup
 
 ## Details
 
@@ -27,7 +27,7 @@ grammar:
 
 _Command_
 
-    trparse Expression.g4 | trrup | trprint
+    dotnet trash parse Expression.g4 | dotnet trash rup | dotnet trash text
 
 _Result_
 

--- a/src/trsem/readme.md
+++ b/src/trsem/readme.md
@@ -10,11 +10,11 @@ Read a static semantics spec file and generate code.
 
 ## Usage
 
-    trsem
+    dotnet trash sem
 
 ## Examples
 
-    trsem
+    dotnet trash sem
 
 ## Current version
 

--- a/src/trsort/readme.md
+++ b/src/trsort/readme.md
@@ -12,9 +12,9 @@ to stdout. The input and output are Parse Tree Data.
 
 ## Usage
 
-    trsort [-a]
-    trsort --bfs [<start-rule>]
-    trsort --dfs [<start-rule>]
+    dotnet trash sort [-a]
+    dotnet trash sort --bfs [<start-rule>]
+    dotnet trash sort --dfs [<start-rule>]
 
 ## Details
 
@@ -36,9 +36,9 @@ Only one mode flag may be specified at a time.
 
 ## Example
 
-    dotnet trash parse Java.g4 | dotnet trash trsort -a | dotnet trash sponge -o out -c
-    dotnet trash parse Java.g4 | dotnet trash trsort --dfs compilationUnit | dotnet trash sponge -o out -c
-    dotnet trash parse Java.g4 | dotnet trash trsort --bfs | dotnet trash sponge -o out -c
+    dotnet trash parse Java.g4 | dotnet trash sort -a | dotnet trash sponge -c
+    dotnet trash parse Java.g4 | dotnet trash sort --dfs compilationUnit | dotnet trash sponge -c
+    dotnet trash parse Java.g4 | dotnet trash sort --bfs | dotnet trash sponge -c
 
 ## Current version
 

--- a/src/trsplit/readme.md
+++ b/src/trsplit/readme.md
@@ -15,7 +15,7 @@ is used to instantiate the two files in the file system.
 
 ## Usage
 
-    trsplit
+    dotnet trash split
 
 ## Details
 
@@ -41,7 +41,7 @@ modified.
 
 ## Example
 
-    trparse Arithmetic.g4 | trsplit | trsponge
+    dotnet trash parse Arithmetic.g4 | dotnet trash split | dotnet trash sponge
 
 ## Current version
 

--- a/src/trsponge/readme.md
+++ b/src/trsponge/readme.md
@@ -11,11 +11,11 @@ results to file(s).
 
 ## Usage
 
-    trsponge <options>
+    dotnet trash sponge <options>
 
 ## Example
 
-    trparse Arithmetic.g4 | trsplit | trsponge
+    dotnet trash parse Arithmetic.g4 | dotnet trash split | dotnet trash sponge
 
 ## Current version
 

--- a/src/trtext/readme.md
+++ b/src/trtext/readme.md
@@ -11,11 +11,16 @@ specified, the line number range for the tree is printed.
 
 ## Usage
 
-    trtext line-number?
+    dotnet trash text [-n] [-l] [-L] [-c]
+
+    -n, --line-number          Print line number with output lines.
+    -l, --files-with-matches   Print only names of files with selected lines.
+    -L, --files-without-match  Print only names of files with no selected lines.
+    -c, --count                Print only a count of selected lines per file.
 
 ## Examples
 
-    trquery grep //lexerRuleSpec | trtext
+    dotnet trash query "grep //lexerRuleSpec" | dotnet trash text
 
 ## Current version
 

--- a/src/trtokens/readme.md
+++ b/src/trtokens/readme.md
@@ -12,7 +12,7 @@ for the tree are computed and printed, with a blank line separator.
 
 ## Usage
 
-    trtokens
+    dotnet trash tokens
 
 ## Examples
 
@@ -22,7 +22,7 @@ Input:
 
 Command:
 
-    trparse -i "1 * 2 + 3" | trquery "grep //expression" | trtokens
+    dotnet trash parse -i "1 * 2 + 3" | dotnet trash query "grep //expression" | dotnet trash tokens
 
 Output:
 

--- a/src/trtree/readme.md
+++ b/src/trtree/readme.md
@@ -10,11 +10,11 @@ Reads a tree from stdin and prints the tree as an indented node list.
 
 ## Usage
 
-    trtree
+    dotnet trash tree
 
 ## Examples
 
-    trparse A.g4 | trtree
+    dotnet trash parse A.g4 | dotnet trash tree
 
 ## Current version
 

--- a/src/trull/readme.md
+++ b/src/trull/readme.md
@@ -13,7 +13,7 @@ whole file.
 
 ## Usage
 
-    trull <xpath>?
+    dotnet trash ull <xpath>?
 
 ## Examples
 
@@ -29,7 +29,7 @@ Before:
 
 Command:
 
-    trparse KeywordFun.g4 | trull "//lexerRuleSpec[TOKEN_REF/text() = 'A']//STRING_LITERAL" | trprint
+    dotnet trash parse KeywordFun.g4 | dotnet trash ull "//lexerRuleSpec[TOKEN_REF/text() = 'A']//STRING_LITERAL" | dotnet trash text
 
 After:
 
@@ -43,7 +43,7 @@ After:
 
 Command:
 
-    trparse KeywordFun.g4 | trull | trprint
+    dotnet trash parse KeywordFun.g4 | dotnet trash ull | dotnet trash text
 
 After:
 

--- a/src/trunfold/readme.md
+++ b/src/trunfold/readme.md
@@ -14,13 +14,13 @@ occurs at the specified node.
 
 ## Usage
 
-    trunfold <string>
+    dotnet trash unfold <string>
 
 ## Examples
 
 Before:
 
-	grammar Expresion;
+	grammar Expression;
 	s : e ;
 	e : e '*' e       # Mult
 	    | INT           # primary
@@ -30,7 +30,7 @@ Before:
 
 Command:
 
-    trparse Expression.g4 | trunfold "//parserRuleSpec[RULE_REF/text() = 's']//labeledAlt//RULE_REF[text() = 'e']" | trsponge -c
+    dotnet trash parse Expression.g4 | dotnet trash unfold "//parserRuleSpec[RULE_REF/text() = 's']//labeledAlt//RULE_REF[text() = 'e']" | dotnet trash sponge -c
 
 After:
 

--- a/src/trunfoldlit/readme.md
+++ b/src/trunfoldlit/readme.md
@@ -8,40 +8,56 @@ Perform an unfold transform for all string literal lexer rules on a grammar
 
 The unfoldlit command applies the unfold transform to a collection of terminal nodes
 for string literal lexer rules in a grammar. An unfold operation substitutes
-the right-hand side of a parser or lexer rule into a reference of the rule name that
-occurs at the specified node. In this app, all lexer rules that have a string literal
-on the right-hand side of the rule are identified as the symbols to unfold in parser
-rules.
+the right-hand side of a lexer rule into every reference of that rule name in
+parser rules. In this app, all lexer rules whose right-hand side is a single
+string literal are identified as the symbols to unfold in parser rules.
+This is the inverse of `dotnet trash foldlit`.
 
 ## Usage
 
-    trunfoldlit
+    dotnet trash unfoldlit
 
 ## Examples
 
 Before:
 
 	grammar Expression;
-	s : ( e '*' e | INT ) ;
-	e : e '*' e           # Mult
-		| INT               # primary
-		;
-	INT : [0-9]+ ;
-	WS : [ \t\n]+ -> skip ;
+	e : e (MUL | DIV) e
+	  | e (ADD | SUB) e
+	  | LP e RP
+	  | (SUB | ADD)* a
+	  ;
+	a : INT ;
+	INT : ('0' .. '9')+ ;
+	MUL : '*' ;
+	DIV : '/' ;
+	ADD : '+' ;
+	SUB : '-' ;
+	LP : '(' ;
+	RP : ')' ;
+	WS : [ \r\n\t] + -> skip ;
 
 Command:
 
-    trparse Expression.g4 | trunfoldlit | trsponge -c
+    dotnet trash parse Expression.g4 | dotnet trash unfoldlit | dotnet trash sponge -c
 
 After:
 
-	grammar Expresion;
-	s : e ;
-	e : e '*' e       # Mult
-	    | INT           # primary
-	    ;
-	INT : [0-9]+ ;
-	WS : [ \t\n]+ -> skip ;
+	grammar Expression;
+	e : e ('*' | '/') e
+	  | e ('+' | '-') e
+	  | '(' e ')'
+	  | ('-' | '+')* a
+	  ;
+	a : INT ;
+	INT : ('0' .. '9')+ ;
+	MUL : '*' ;
+	DIV : '/' ;
+	ADD : '+' ;
+	SUB : '-' ;
+	LP : '(' ;
+	RP : ')' ;
+	WS : [ \r\n\t] + -> skip ;
 
 ## Notes
 
@@ -59,23 +75,23 @@ The MIT License
 
 Copyright (c) 2025 Ken Domino
 
-Permission is hereby granted, free of charge, 
-to any person obtaining a copy of this software and 
-associated documentation files (the "Software"), to 
-deal in the Software without restriction, including 
-without limitation the rights to use, copy, modify, 
-merge, publish, distribute, sublicense, and/or sell 
-copies of the Software, and to permit persons to whom 
-the Software is furnished to do so, 
+Permission is hereby granted, free of charge,
+to any person obtaining a copy of this software and
+associated documentation files (the "Software"), to
+deal in the Software without restriction, including
+without limitation the rights to use, copy, modify,
+merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom
+the Software is furnished to do so,
 subject to the following conditions:
 
-The above copyright notice and this permission notice 
+The above copyright notice and this permission notice
 shall be included in all copies or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, 
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES 
-OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. 
-IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR 
-ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, 
-TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE 
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR
+ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/src/trungroup/readme.md
+++ b/src/trungroup/readme.md
@@ -10,11 +10,11 @@ Perform an ungroup transformation of the 'element' node(s) specified by the stri
 
 ## Usage
 
-    trungroup <string>
+    dotnet trash ungroup <string>
 
 ## Examples
 
-    trparse A.g4 | trungroup "//parserRuleSpec[RULE_REF/text() = 'a']//ruleAltList"
+    dotnet trash parse A.g4 | dotnet trash ungroup "//parserRuleSpec[RULE_REF/text() = 'a']//ruleAltList"
 
 ## Notes
 

--- a/src/trwdog/readme.md
+++ b/src/trwdog/readme.md
@@ -10,11 +10,11 @@ Execute a command with a watchdog timer.
 
 ## Usage
 
-    trwdog <arg>+
+    dotnet trash wdog <arg>+
 
 ## Examples
 
-    trwdog make test
+    dotnet trash wdog make test
 
 ## Current version
 

--- a/src/trxml/readme.md
+++ b/src/trxml/readme.md
@@ -10,11 +10,11 @@ Read a tree from stdin and write an XML represenation of it.
 
 ## Usage
 
-    trxml
+    dotnet trash xml
 
 ## Examples
 
-    trparse A.g4 | trxml
+    dotnet trash parse A.g4 | dotnet trash xml
 
 ## Current version
 

--- a/src/trxml2/readme.md
+++ b/src/trxml2/readme.md
@@ -10,11 +10,11 @@ Read an xml file and enumerate all paths to elements in xpath syntax.
 
 ## Usage
 
-    trxml2
+    dotnet trash xml2
 
 ## Examples
 
-    cat desc.xml | trxml2
+    cat desc.xml | dotnet trash xml2
 
 ## Current version
 

--- a/src/trxpath/readme.md
+++ b/src/trxpath/readme.md
@@ -10,11 +10,11 @@ Find all sub-trees in a parse tree using the given XPath expression.
 
 ## Usage
 
-    trxpath <string>
+    dotnet trash xpath <string>
 
 ## Examples
 
-    trparse A.g4 | trxpath "//parserRuleSpec[RULE_REF/text() = 'normalAnnotation']"
+    dotnet trash parse A.g4 | dotnet trash xpath "//parserRuleSpec[RULE_REF/text() = 'normalAnnotation']"
 
 ## Notes
 

--- a/src/trxquery/readme.md
+++ b/src/trxquery/readme.md
@@ -4,8 +4,8 @@ Apply XQuery 4.0 Update expressions to a Trash parse tree.
 
 ## Synopsis
 
-    ... | trxquery '<xquery-expression>'
-    ... | trxquery -q <query-file>
+    ... | dotnet trash xquery '<xquery-expression>'
+    ... | dotnet trash xquery -q <query-file>
 
 ## Description
 
@@ -15,7 +15,7 @@ context document, and emits the (possibly mutated) parse tree on stdout.
 
 Mutations are applied using the XQuery Update Facility (insert/delete/replace/rename)
 directly on the underlying parse tree nodes via `TreeEdits`, so the result can be
-piped to other Trash tools (e.g. `trprint`).
+piped to other Trash tools (e.g. `dotnet trash text`).
 
 ## XQuery Update syntax
 
@@ -55,8 +55,8 @@ Rename an element:
 
 Delete all `WS` tokens from a parse tree:
 
-    dotnet trash parse Foo.g4 | trxquery 'delete node //WS'
+    dotnet trash parse Foo.g4 | dotnet trash xquery 'delete node //WS'
 
 Replace the text of the first `ID` token:
 
-    dotnet trash parse Foo.g4 | trxquery 'replace value of node (//ID)[1] with "myNewName"'
+    dotnet trash parse Foo.g4 | dotnet trash xquery 'replace value of node (//ID)[1] with "myNewName"'


### PR DESCRIPTION
## Summary

- Add missing commands (`trinterp`, `trxquery`) to top-level command list and `trash` dispatcher table
- Replace all standalone binary invocations (`trparse`, `trdot`, etc.) with `dotnet trash <command>` form throughout every tool readme
- Replace all `trprint` references with `dotnet trash text`
- Remove non-existent `strip` command example from top-level readme
- Remove non-existent `trst`, `tragl`, `trprint` references from "Display parse tree" section
- Fix typos: `trconvert` summary "for"→"form", `trdot` summary "Graphvis"→"Graphviz", `trglob` usage wrong tool name, `triconv` example `triconf`→`dotnet trash iconv`, `trperf` usage `-c.`→`-c,`
- Fix `triconv` summary (was "Test whether a file is proper Unicode") and option names (`--from-code`/`--to-code`)
- Fix `trparse` `--type` descriptions (ANTLRv4/ANTLRv2 were swapped)
- Fix `trperf` example `dotnet trperf`→`dotnet trash perf`
- Fix `trsort` examples to use canonical alias (`sort` instead of `trsort`)
- Fix `trtext` usage (no positional arg; now shows actual option flags from Config)
- Fix `trunfold` "Expresion" typo in grammar name
- Fix `trunfoldlit` before/after example (was showing the wrong transform — reverse of trunfold rather than unfold of literals)
- Fix `trdistill` (was a verbatim copy of `trconvert` content)
- Fix `greap`→`grep` typo in top-level readme count example
- Remove `sponge -o true` (invalid flag usage) from split grammar example

## Test plan

- [ ] Verify `dotnet trash interp` and `dotnet trash xquery` appear in the top-level command list and `trash` dispatcher readme table
- [ ] Spot-check a few tool readmes to confirm `dotnet trash <command>` form is used consistently
- [ ] Confirm `trunfoldlit` before/after example shows the correct inverse-of-foldlit transform
- [ ] Confirm `trtext` usage section lists the actual option flags

🤖 Generated with [Claude Code](https://claude.com/claude-code)