### PR TITLE
Bump NuGet dependencies (Dependabot PRs #646-#650)

### DIFF
--- a/src/ParseTreeEditing/ParseTreeEditing.csproj
+++ b/src/ParseTreeEditing/ParseTreeEditing.csproj
@@ -5,7 +5,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.301" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.400" PrivateAssets="all" />
   </ItemGroup>
   
   <ItemGroup>

--- a/src/trwdog/trwdog.csproj
+++ b/src/trwdog/trwdog.csproj
@@ -26,7 +26,7 @@ This program is part of the Trash toolkit.
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="System.Management" Version="10.0.10" />
+		<PackageReference Include="System.Management" Version="10.0.11" />
 		<PackageReference Include="CommandLineParser" Version="2.9.1" />
 	</ItemGroup>
 	<ItemGroup>

--- a/src/web/driver/driver.csproj
+++ b/src/web/driver/driver.csproj
@@ -5,8 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.10" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.10" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.11" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.11" />
    <PackageReference Include="Antlr4.Runtime.Standard" Version="4.13.1" />
     <PackageReference Include="Domemtech.AutomaticGraphLayout" Version="1.1.4" />
     <PackageReference Include="Domemtech.AutomaticGraphLayout.Drawing" Version="1.1.4" />

--- a/src/web/wrap/wrap.csproj
+++ b/src/web/wrap/wrap.csproj
@@ -10,7 +10,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="10.0.10" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="10.0.11" />
     <PackageReference Include="Microsoft.TypeScript.MSBuild" Version="7.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
## Summary

Applies the 5 outstanding Dependabot dependency bumps against the 2.0.1 release:

- `System.Management` 10.0.10 → 10.0.11 (was PR #650)
- `Microsoft.SourceLink.GitHub` 10.0.301 → 10.0.400 (was PR #649)
- `Microsoft.AspNetCore.Components.WebAssembly.DevServer` 10.0.10 → 10.0.11 (was PR #648)
- `Microsoft.AspNetCore.Components.WebAssembly` 10.0.10 → 10.0.11 (was PR #647)
- `Microsoft.AspNetCore.Components.Web` 10.0.10 → 10.0.11 (was PR #646)

## Test plan

- [ ] Verify `dotnet restore` succeeds with the updated package versions
- [ ] Verify `dotnet build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)