### PR TITLE
Fix wrong tool names in help headings.

### DIFF
--- a/src/trclonereplace/Program.cs
+++ b/src/trclonereplace/Program.cs
@@ -34,7 +34,7 @@ public class Program
             helpText = HelpText.AutoBuild(result, h =>
             {
                 h.AdditionalNewLineAfterOption = false;
-                h.Heading = "trrename";
+                h.Heading = "trclonereplace";
                 h.Copyright = "Copyright (c) 2026 Ken Domino"; //change copyright text
                 h.AddPreOptionsText(new Command().Help());
                 return HelpText.DefaultParsingErrorsHandler(result, h);

--- a/src/trdistill/Program.cs
+++ b/src/trdistill/Program.cs
@@ -34,7 +34,7 @@ public class Program
             helpText = HelpText.AutoBuild(result, h =>
             {
                 h.AdditionalNewLineAfterOption = false;
-                h.Heading = "trconvert";
+                h.Heading = "trdistill";
                 h.Copyright = "Copyright (c) 2026 Ken Domino"; //change copyright text
                 h.AddPreOptionsText(new Command().Help());
                 return HelpText.DefaultParsingErrorsHandler(result, h);

--- a/src/trquery/Program.cs
+++ b/src/trquery/Program.cs
@@ -34,7 +34,7 @@ public class Program
             helpText = HelpText.AutoBuild(result, h =>
             {
                 h.AdditionalNewLineAfterOption = false;
-                h.Heading = "trinsert";
+                h.Heading = "trquery";
                 h.Copyright = "Copyright (c) 2026 Ken Domino"; //change copyright text
                 h.AddPreOptionsText(new Command().Help());
                 return HelpText.DefaultParsingErrorsHandler(result, h);


### PR DESCRIPTION
trclonereplace, trquery, and trdistill were showing incorrect tool names ("trrename", "trinsert", "trconvert") in --help output.