### PR TITLE
Add glob alternation/negation support; fix trgen for multiple <inputs>

### DIFF
--- a/src/Globbing/Globbing.cs
+++ b/src/Globbing/Globbing.cs
@@ -70,8 +70,17 @@ namespace TrashGlobbing
                         break;
                     case '{':
                         // Begin alternation group: {a,b,c} → (?:a|b|c)
-                        braceDepth++;
-                        regex.Append("(?:");
+                        // Only treat as alternation when a matching '}' exists; otherwise
+                        // emit a literal '\{' so the regex stays valid.
+                        if (HasMatchingBrace(glob, ptr + 1))
+                        {
+                            braceDepth++;
+                            regex.Append("(?:");
+                        }
+                        else
+                        {
+                            regex.Append("\\{");
+                        }
                         break;
                     case '}':
                         if (braceDepth > 0)
@@ -100,6 +109,23 @@ namespace TrashGlobbing
             }
             regex.Append("$");
             return regex.ToString();
+        }
+
+        // Returns true if there is a '}' in glob[start..] that closes the
+        // immediately enclosing '{' (i.e. at brace depth 0 relative to start).
+        private static bool HasMatchingBrace(string glob, int start)
+        {
+            int depth = 0;
+            for (int i = start; i < glob.Length; i++)
+            {
+                if (glob[i] == '{') depth++;
+                else if (glob[i] == '}')
+                {
+                    if (depth == 0) return true;
+                    depth--;
+                }
+            }
+            return false;
         }
 
         private List<DirectoryInfo> GetDirectory(string cwd, string expr)

--- a/src/Globbing/Globbing.cs
+++ b/src/Globbing/Globbing.cs
@@ -26,6 +26,7 @@ namespace TrashGlobbing
         {
             var regex = new StringBuilder();
             var characterClass = false;
+            int braceDepth = 0;
             regex.Append("^");
             int ptr = 0;
             for ( ; ptr < glob.Length; ++ptr)
@@ -66,6 +67,30 @@ namespace TrashGlobbing
                     case '[':
                         characterClass = true;
                         regex.Append(c);
+                        break;
+                    case '{':
+                        // Begin alternation group: {a,b,c} → (?:a|b|c)
+                        braceDepth++;
+                        regex.Append("(?:");
+                        break;
+                    case '}':
+                        if (braceDepth > 0)
+                        {
+                            braceDepth--;
+                            regex.Append(")");
+                        }
+                        else
+                        {
+                            // Unmatched '}' — treat as literal
+                            regex.Append("\\}");
+                        }
+                        break;
+                    case ',':
+                        // Inside braces ',' is the alternation separator; outside it is literal
+                        if (braceDepth > 0)
+                            regex.Append("|");
+                        else
+                            regex.Append(",");
                         break;
                     default:
                         if (RegexSpecialChars.Contains(c)) regex.Append('\\');

--- a/src/trgen/Command.cs
+++ b/src/trgen/Command.cs
@@ -915,14 +915,18 @@ namespace Trash
                 }
             }
             {
-                var spec_examplesy = navigator
+                var spec_all_inputs = navigator
                     .Select("/desc/inputs", nsmgr)
                     .Cast<XPathNavigator>()
-                    .Select(t => t.Value)
-                    .FirstOrDefault();
-                if (config.example_files == null && spec_examplesy != null)
+                    .Select(t => t.Value.Trim())
+                    .Where(t => t != "")
+                    .ToList();
+                if (spec_all_inputs.Any())
                 {
-                    config.example_files = spec_examplesy;
+                    config.all_example_files = spec_all_inputs;
+                    var firstPositive = spec_all_inputs.FirstOrDefault(p => !p.StartsWith("!"));
+                    if (config.example_files == null && firstPositive != null)
+                        config.example_files = firstPositive;
                 }
             }
             {
@@ -997,6 +1001,10 @@ namespace Trash
                         test.grammar_name = config.grammar_name;
                         test.start_rule = config.start_rule;
                         test.example_files = config.example_files;
+                        test.all_example_files = config.all_example_files
+                            ?? (config.example_files != null
+                                ? new List<string> { config.example_files }
+                                : new List<string> { "examples" });
                         if (test.example_files == null)
                         {
                             test.example_files = "examples";
@@ -1162,12 +1170,15 @@ namespace Trash
                         .Where(t => t.Value != "")
                         .Select(t => t.Value)
                         .FirstOrDefault();
-                    var spec_examplesy = xmltest
+                    var spec_all_inputs_test = xmltest
                         .Select("inputs", nsmgr)
                         .Cast<XPathNavigator>()
-                        .Where(t => t.Value != "")
-                        .Select(t => t.Value)
-                        .FirstOrDefault();
+                        .Select(t => t.Value.Trim())
+                        .Where(t => t != "")
+                        .ToList();
+                    var spec_examplesy = spec_all_inputs_test.Any()
+                        ? spec_all_inputs_test.FirstOrDefault(p => !p.StartsWith("!"))
+                        : null;
                     var all = config.force ? config.targets : test_targets.Intersect(config.targets);
                     foreach (var os_target in test_ostargets)
                     {
@@ -1214,13 +1225,19 @@ namespace Trash
                             if (spec_examplesy != null)
                             {
                                 test.example_files = spec_examplesy;
+                                test.all_example_files = spec_all_inputs_test.Any()
+                                    ? spec_all_inputs_test
+                                    : new List<string> { spec_examplesy };
                             } else if (config.example_files != null)
                             {
                                 test.example_files = config.example_files.Trim();
+                                test.all_example_files = config.all_example_files
+                                    ?? new List<string> { config.example_files.Trim() };
                             }
                             else
                             {
                                 test.example_files = "examples";
+                                test.all_example_files = new List<string> { "examples" };
                             }
 
                             if (spec_antlr_tool_args.Contains("-package"))
@@ -1851,6 +1868,16 @@ namespace Trash
             t.Add("example_files_win", RemoveTrailingSlash(test.example_files.Replace('/', '\\')));
             t.Add("example_dir_unix", RemoveTrailingSlash(GetBaseDir(test.example_files.Replace('\\', '/'))));
             t.Add("example_dir_win", RemoveTrailingSlash(GetBaseDir(test.example_files.Replace('/', '\\'))));
+            // Pre-compute single-quoted glob arguments for generated shell/ps1 scripts.
+            // Negation patterns (starting with '!') get a '!../' prefix; others get '../'.
+            var globArgsUnix = string.Join(" ", test.all_example_files.Select(p =>
+                p.StartsWith("!") ? $"'!../{p.Substring(1).Replace('\\', '/')}'"
+                                  : $"'../{p.Replace('\\', '/')}'"));
+            var globArgsWin = string.Join(" ", test.all_example_files.Select(p =>
+                p.StartsWith("!") ? $"'!..\\{p.Substring(1).Replace('/', '\\')}'"
+                                  : $"'..\\{p.Replace('/', '\\')}'"));
+            t.Add("glob_args_unix", globArgsUnix);
+            t.Add("glob_args_win",  globArgsWin);
             t.Add("exec_name", GetOSTarget() == OSPlatform.Windows ? "Test.exe" : "Test");
             t.Add("go_lexer_name", test.fully_qualified_go_lexer_name);
             t.Add("go_parser_name", test.fully_qualified_go_parser_name);

--- a/src/trgen/Config.cs
+++ b/src/trgen/Config.cs
@@ -76,6 +76,7 @@ public class Config
     public string SetupFfn = ".trgen.rc";
     public string root_directory;
     public string example_files { get; set; }
+    public List<string> all_example_files { get; set; }
 
     public List<Test> Tests;
 

--- a/src/trgen/Test.cs
+++ b/src/trgen/Test.cs
@@ -15,6 +15,7 @@ namespace Trash
         public CaseInsensitiveType? case_insensitive_type { get; set; } = null;
         public string current_directory;
         public string example_files { get; set; } = "examples/";
+        public List<string> all_example_files { get; set; } = new List<string> { "examples/" };
         public string fully_qualified_lexer_name { get; set; }
         public string fully_qualified_listener_name { get; set; }
         public string fully_qualified_parser_name { get; set; }

--- a/src/trgen/templates/Antlr4cs/st.Test.csproj
+++ b/src/trgen/templates/Antlr4cs/st.Test.csproj
@@ -28,7 +28,7 @@
     -->
     \<MyTester>\<![CDATA[
 err=0
-for g in `dotnet trash glob -- '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
+for g in `dotnet trash glob -- <glob_args_unix> | grep -v '.errors$' | grep -v '.tree$'`
 do
   file=$g
   x1="${g##*.}"

--- a/src/trgen/templates/Antlr4cs/st.perf.sh
+++ b/src/trgen/templates/Antlr4cs/st.perf.sh
@@ -56,7 +56,7 @@ echo "" >> parse.txt
 # Get a list of test files from the test directory. Do not include any
 # .errors or .tree files. Pay close attention to remove only file names
 # that end with the suffix .errors or .tree.
-files2=`dotnet trash glob '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
+files2=`dotnet trash glob <glob_args_unix> | grep -v '.errors$' | grep -v '.tree$'`
 files=()
 for f in $files2
 do

--- a/src/trgen/templates/Antlr4cs/st.test.ps1
+++ b/src/trgen/templates/Antlr4cs/st.test.ps1
@@ -3,8 +3,7 @@
 $workingDirectory = Get-Location
 $filePath = "$workingDirectory/tests.txt"
 
-$Tests = "<if(os_win)>../<example_files_win><else>../<example_files_unix><endif>"
-Write-Host "Test cases here: $Tests"
+Write-Host "Test cases: <glob_args_win>"
 
 # Get a list of test files from the test directory. Do not include any
 # .errors or .tree files. Pay close attention to remove only file names
@@ -14,7 +13,7 @@ if (Test-Path -Path "$filePath" -PathType Leaf) {
 }
 
 $files = New-Object System.Collections.Generic.List[string]
-$allFiles = $(& dotnet trash glob "$Tests" ; $last = $LASTEXITCODE )
+$allFiles = $(& dotnet trash glob <glob_args_win> ; $last = $LASTEXITCODE )
 foreach ($file in $allFiles) {
     $ext = $file | Split-Path -Extension
     if (Test-Path $file -PathType Container) {

--- a/src/trgen/templates/Antlr4cs/st.test.sh
+++ b/src/trgen/templates/Antlr4cs/st.test.sh
@@ -22,7 +22,7 @@ esac
 # Get a list of test files from the test directory. Do not include any
 # .errors or .tree files. Pay close attention to remove only file names
 # that end with the suffix .errors or .tree.
-files2=`dotnet trash glob '../<example_files_unix>' | tr -d '\r' | grep -v '[.]errors$' | grep -v '[.]tree$' | grep -v '[.]trq$'`
+files2=`dotnet trash glob <glob_args_unix> | tr -d '\r' | grep -v '[.]errors$' | grep -v '[.]tree$' | grep -v '[.]trq$'`
 files=()
 for f in $files2
 do

--- a/src/trgen/templates/Antlr4ng/st.perf.sh
+++ b/src/trgen/templates/Antlr4ng/st.perf.sh
@@ -56,7 +56,7 @@ echo "" >> parse.txt
 # Get a list of test files from the test directory. Do not include any
 # .errors or .tree files. Pay close attention to remove only file names
 # that end with the suffix .errors or .tree.
-files2=`dotnet trash glob '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
+files2=`dotnet trash glob <glob_args_unix> | grep -v '.errors$' | grep -v '.tree$'`
 files=()
 for f in $files2
 do

--- a/src/trgen/templates/Antlr4ng/st.test.ps1
+++ b/src/trgen/templates/Antlr4ng/st.test.ps1
@@ -3,8 +3,7 @@
 $workingDirectory = Get-Location
 $filePath = "$workingDirectory/tests.txt"
 
-$Tests = "<if(os_win)>../<example_files_win><else>../<example_files_unix><endif>"
-Write-Host "Test cases here: $Tests"
+Write-Host "Test cases: <glob_args_win>"
 
 # Get a list of test files from the test directory. Do not include any
 # .errors or .tree files. Pay close attention to remove only file names
@@ -14,7 +13,7 @@ if (Test-Path -Path "$filePath" -PathType Leaf) {
 }
 
 $files = New-Object System.Collections.Generic.List[string]
-$allFiles = $(& dotnet trash glob "$Tests" ; $last = $LASTEXITCODE )
+$allFiles = $(& dotnet trash glob <glob_args_win> ; $last = $LASTEXITCODE )
 foreach ($file in $allFiles) {
     $ext = $file | Split-Path -Extension
     if (Test-Path $file -PathType Container) {

--- a/src/trgen/templates/Antlr4ng/st.test.sh
+++ b/src/trgen/templates/Antlr4ng/st.test.sh
@@ -22,7 +22,7 @@ esac
 # Get a list of test files from the test directory. Do not include any
 # .errors or .tree files. Pay close attention to remove only file names
 # that end with the suffix .errors or .tree.
-files2=`dotnet trash glob '../<example_files_unix>' | tr -d '\r' | grep -v '[.]errors$' | grep -v '[.]tree$' | grep -v '[.]trq$'`
+files2=`dotnet trash glob <glob_args_unix> | tr -d '\r' | grep -v '[.]errors$' | grep -v '[.]tree$' | grep -v '[.]trq$'`
 files=()
 for f in $files2
 do

--- a/src/trgen/templates/CSharp/st.perf.sh
+++ b/src/trgen/templates/CSharp/st.perf.sh
@@ -56,7 +56,7 @@ echo "" >> parse.txt
 # Get a list of test files from the test directory. Do not include any
 # .errors or .tree files. Pay close attention to remove only file names
 # that end with the suffix .errors or .tree.
-files2=`dotnet trash glob '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
+files2=`dotnet trash glob <glob_args_unix> | grep -v '.errors$' | grep -v '.tree$'`
 files=()
 for f in $files2
 do

--- a/src/trgen/templates/CSharp/st.test-ambiguity.sh
+++ b/src/trgen/templates/CSharp/st.test-ambiguity.sh
@@ -6,7 +6,7 @@ IFS=$(echo -en "\n\b")
 # Get a list of test files from the test directory. Do not include any
 # .errors or .tree files. Pay close attention to remove only file names
 # that end with the suffix .errors or .tree.
-files2=`dotnet trash glob '../<example_files_unix>' | grep -v '[.]errors$' | grep -v '[.]tree$' | grep -v '[.]trq$'`
+files2=`dotnet trash glob <glob_args_unix> | grep -v '[.]errors$' | grep -v '[.]tree$' | grep -v '[.]trq$'`
 files=()
 for f in $files2
 do

--- a/src/trgen/templates/CSharp/st.test-cover.sh
+++ b/src/trgen/templates/CSharp/st.test-cover.sh
@@ -6,7 +6,7 @@ IFS=$(echo -en "\n\b")
 # Get a list of test files from the test directory. Do not include any
 # .errors or .tree files. Pay close attention to remove only file names
 # that end with the suffix .errors or .tree.
-files2=`dotnet trash glob '../<example_files_unix>' | grep -v '[.]errors$' | grep -v '[.]tree$' | grep -v '[.]trq$'`
+files2=`dotnet trash glob <glob_args_unix> | grep -v '[.]errors$' | grep -v '[.]tree$' | grep -v '[.]trq$'`
 files=()
 for f in $files2
 do

--- a/src/trgen/templates/CSharp/st.test.ps1
+++ b/src/trgen/templates/CSharp/st.test.ps1
@@ -3,8 +3,7 @@
 $workingDirectory = Get-Location
 $filePath = "$workingDirectory/tests.txt"
 
-$Tests = "<if(os_win)>../<example_files_win><else>../<example_files_unix><endif>"
-Write-Host "Test cases here: $Tests"
+Write-Host "Test cases: <glob_args_win>"
 
 # Get a list of test files from the test directory. Do not include any
 # .errors or .tree files. Pay close attention to remove only file names
@@ -14,7 +13,7 @@ if (Test-Path -Path "$filePath" -PathType Leaf) {
 }
 
 $files = New-Object System.Collections.Generic.List[string]
-$allFiles = $(& dotnet trash glob "$Tests" ; $last = $LASTEXITCODE )
+$allFiles = $(& dotnet trash glob <glob_args_win> ; $last = $LASTEXITCODE )
 foreach ($file in $allFiles) {
     $ext = $file | Split-Path -Extension
     if (Test-Path $file -PathType Container) {

--- a/src/trgen/templates/CSharp/st.test.sh
+++ b/src/trgen/templates/CSharp/st.test.sh
@@ -22,7 +22,7 @@ esac
 # Get a list of test files from the test directory. Do not include any
 # .errors or .tree files. Pay close attention to remove only file names
 # that end with the suffix .errors or .tree.
-files2=`dotnet trash glob '../<example_files_unix>' | tr -d '\r' | grep -v '[.]errors$' | grep -v '[.]tree$' | grep -v '[.]trq$'`
+files2=`dotnet trash glob <glob_args_unix> | tr -d '\r' | grep -v '[.]errors$' | grep -v '[.]tree$' | grep -v '[.]trq$'`
 files=()
 for f in $files2
 do
@@ -96,7 +96,7 @@ fi
 # Execute trquery parse tree validation.
 echo "Checking any trquery parse tree assertions..."
 assertions_err=0
-for file in `dotnet trash glob '../<example_files_unix>' | grep -v '[.]errors$' | grep -v '[.]tree$' | grep -v '[.]trq$'`
+for file in `dotnet trash glob <glob_args_unix> | grep -v '[.]errors$' | grep -v '[.]tree$' | grep -v '[.]trq$'`
 do
     trq=$file.trq
     if [ -f "$trq" ]

--- a/src/trgen/templates/Cpp/st.perf.sh
+++ b/src/trgen/templates/Cpp/st.perf.sh
@@ -56,7 +56,7 @@ echo "" >> parse.txt
 # Get a list of test files from the test directory. Do not include any
 # .errors or .tree files. Pay close attention to remove only file names
 # that end with the suffix .errors or .tree.
-files2=`dotnet trash glob '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
+files2=`dotnet trash glob <glob_args_unix> | grep -v '.errors$' | grep -v '.tree$'`
 files=()
 for f in $files2
 do

--- a/src/trgen/templates/Cpp/st.test.ps1
+++ b/src/trgen/templates/Cpp/st.test.ps1
@@ -3,8 +3,7 @@
 $workingDirectory = Get-Location
 $filePath = "$workingDirectory/tests.txt"
 
-$Tests = "<if(os_win)>../<example_files_win><else>../<example_files_unix><endif>"
-Write-Host "Test cases here: $Tests"
+Write-Host "Test cases: <glob_args_win>"
 
 # Get a list of test files from the test directory. Do not include any
 # .errors or .tree files. Pay close attention to remove only file names
@@ -14,7 +13,7 @@ if (Test-Path -Path "$filePath" -PathType Leaf) {
 }
 
 $files = New-Object System.Collections.Generic.List[string]
-$allFiles = $(& dotnet trash glob "$Tests" ; $last = $LASTEXITCODE )
+$allFiles = $(& dotnet trash glob <glob_args_win> ; $last = $LASTEXITCODE )
 foreach ($file in $allFiles) {
     $ext = $file | Split-Path -Extension
     if (Test-Path $file -PathType Container) {

--- a/src/trgen/templates/Cpp/st.test.sh
+++ b/src/trgen/templates/Cpp/st.test.sh
@@ -22,7 +22,7 @@ esac
 # Get a list of test files from the test directory. Do not include any
 # .errors or .tree files. Pay close attention to remove only file names
 # that end with the suffix .errors or .tree.
-files2=`dotnet trash glob '../<example_files_unix>' | tr -d '\r' | grep -v '[.]errors$' | grep -v '[.]tree$' | grep -v '[.]trq$'`
+files2=`dotnet trash glob <glob_args_unix> | tr -d '\r' | grep -v '[.]errors$' | grep -v '[.]tree$' | grep -v '[.]trq$'`
 files=()
 for f in $files2
 do

--- a/src/trgen/templates/Dart/st.perf.sh
+++ b/src/trgen/templates/Dart/st.perf.sh
@@ -56,7 +56,7 @@ echo "" >> parse.txt
 # Get a list of test files from the test directory. Do not include any
 # .errors or .tree files. Pay close attention to remove only file names
 # that end with the suffix .errors or .tree.
-files2=`dotnet trash glob '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
+files2=`dotnet trash glob <glob_args_unix> | grep -v '.errors$' | grep -v '.tree$'`
 files=()
 for f in $files2
 do

--- a/src/trgen/templates/Dart/st.test.ps1
+++ b/src/trgen/templates/Dart/st.test.ps1
@@ -3,8 +3,7 @@
 $workingDirectory = Get-Location
 $filePath = "$workingDirectory/tests.txt"
 
-$Tests = "<if(os_win)>../<example_files_win><else>../<example_files_unix><endif>"
-Write-Host "Test cases here: $Tests"
+Write-Host "Test cases: <glob_args_win>"
 
 # Get a list of test files from the test directory. Do not include any
 # .errors or .tree files. Pay close attention to remove only file names
@@ -14,7 +13,7 @@ if (Test-Path -Path "$filePath" -PathType Leaf) {
 }
 
 $files = New-Object System.Collections.Generic.List[string]
-$allFiles = $(& dotnet trash glob "$Tests" ; $last = $LASTEXITCODE )
+$allFiles = $(& dotnet trash glob <glob_args_win> ; $last = $LASTEXITCODE )
 foreach ($file in $allFiles) {
     $ext = $file | Split-Path -Extension
     if (Test-Path $file -PathType Container) {

--- a/src/trgen/templates/Dart/st.test.sh
+++ b/src/trgen/templates/Dart/st.test.sh
@@ -22,7 +22,7 @@ esac
 # Get a list of test files from the test directory. Do not include any
 # .errors or .tree files. Pay close attention to remove only file names
 # that end with the suffix .errors or .tree.
-files2=`dotnet trash glob '../<example_files_unix>' | tr -d '\r' | grep -v '[.]errors$' | grep -v '[.]tree$' | grep -v '[.]trq$'`
+files2=`dotnet trash glob <glob_args_unix> | tr -d '\r' | grep -v '[.]errors$' | grep -v '[.]tree$' | grep -v '[.]trq$'`
 files=()
 for f in $files2
 do

--- a/src/trgen/templates/Go/st.perf.sh
+++ b/src/trgen/templates/Go/st.perf.sh
@@ -56,7 +56,7 @@ echo "" >> parse.txt
 # Get a list of test files from the test directory. Do not include any
 # .errors or .tree files. Pay close attention to remove only file names
 # that end with the suffix .errors or .tree.
-files2=`dotnet trash glob '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
+files2=`dotnet trash glob <glob_args_unix> | grep -v '.errors$' | grep -v '.tree$'`
 files=()
 for f in $files2
 do

--- a/src/trgen/templates/Go/st.test.ps1
+++ b/src/trgen/templates/Go/st.test.ps1
@@ -3,8 +3,7 @@
 $workingDirectory = Get-Location
 $filePath = "$workingDirectory/tests.txt"
 
-$Tests = "<if(os_win)>../<example_files_win><else>../<example_files_unix><endif>"
-Write-Host "Test cases here: $Tests"
+Write-Host "Test cases: <glob_args_win>"
 
 # Get a list of test files from the test directory. Do not include any
 # .errors or .tree files. Pay close attention to remove only file names
@@ -14,7 +13,7 @@ if (Test-Path -Path "$filePath" -PathType Leaf) {
 }
 
 $files = New-Object System.Collections.Generic.List[string]
-$allFiles = $(& dotnet trash glob "$Tests" ; $last = $LASTEXITCODE )
+$allFiles = $(& dotnet trash glob <glob_args_win> ; $last = $LASTEXITCODE )
 foreach ($file in $allFiles) {
     $ext = $file | Split-Path -Extension
     if (Test-Path $file -PathType Container) {

--- a/src/trgen/templates/Go/st.test.sh
+++ b/src/trgen/templates/Go/st.test.sh
@@ -22,7 +22,7 @@ esac
 # Get a list of test files from the test directory. Do not include any
 # .errors or .tree files. Pay close attention to remove only file names
 # that end with the suffix .errors or .tree.
-files2=`dotnet trash glob '../<example_files_unix>' | tr -d '\r' | grep -v '[.]errors$' | grep -v '[.]tree$' | grep -v '[.]trq$'`
+files2=`dotnet trash glob <glob_args_unix> | tr -d '\r' | grep -v '[.]errors$' | grep -v '[.]tree$' | grep -v '[.]trq$'`
 files=()
 for f in $files2
 do

--- a/src/trgen/templates/Java/st.perf.sh
+++ b/src/trgen/templates/Java/st.perf.sh
@@ -56,7 +56,7 @@ echo "" >> parse.txt
 # Get a list of test files from the test directory. Do not include any
 # .errors or .tree files. Pay close attention to remove only file names
 # that end with the suffix .errors or .tree.
-files2=`dotnet trash glob '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
+files2=`dotnet trash glob <glob_args_unix> | grep -v '.errors$' | grep -v '.tree$'`
 files=()
 for f in $files2
 do

--- a/src/trgen/templates/Java/st.test.ps1
+++ b/src/trgen/templates/Java/st.test.ps1
@@ -3,8 +3,7 @@
 $workingDirectory = Get-Location
 $filePath = "$workingDirectory/tests.txt"
 
-$Tests = "<if(os_win)>../<example_files_win><else>../<example_files_unix><endif>"
-Write-Host "Test cases here: $Tests"
+Write-Host "Test cases: <glob_args_win>"
 
 # Get a list of test files from the test directory. Do not include any
 # .errors or .tree files. Pay close attention to remove only file names
@@ -14,7 +13,7 @@ if (Test-Path -Path "$filePath" -PathType Leaf) {
 }
 
 $files = New-Object System.Collections.Generic.List[string]
-$allFiles = $(& dotnet trash glob "$Tests" ; $last = $LASTEXITCODE )
+$allFiles = $(& dotnet trash glob <glob_args_win> ; $last = $LASTEXITCODE )
 foreach ($file in $allFiles) {
     $ext = $file | Split-Path -Extension
     if (Test-Path $file -PathType Container) {

--- a/src/trgen/templates/Java/st.test.sh
+++ b/src/trgen/templates/Java/st.test.sh
@@ -22,7 +22,7 @@ esac
 # Get a list of test files from the test directory. Do not include any
 # .errors or .tree files. Pay close attention to remove only file names
 # that end with the suffix .errors or .tree.
-files2=`dotnet trash glob '../<example_files_unix>' | tr -d '\r' | grep -v '[.]errors$' | grep -v '[.]tree$' | grep -v '[.]trq$'`
+files2=`dotnet trash glob <glob_args_unix> | tr -d '\r' | grep -v '[.]errors$' | grep -v '[.]tree$' | grep -v '[.]trq$'`
 files=()
 for f in $files2
 do

--- a/src/trgen/templates/JavaScript/st.perf.sh
+++ b/src/trgen/templates/JavaScript/st.perf.sh
@@ -56,7 +56,7 @@ echo "" >> parse.txt
 # Get a list of test files from the test directory. Do not include any
 # .errors or .tree files. Pay close attention to remove only file names
 # that end with the suffix .errors or .tree.
-files2=`dotnet trash glob '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
+files2=`dotnet trash glob <glob_args_unix> | grep -v '.errors$' | grep -v '.tree$'`
 files=()
 for f in $files2
 do

--- a/src/trgen/templates/JavaScript/st.test.ps1
+++ b/src/trgen/templates/JavaScript/st.test.ps1
@@ -3,8 +3,7 @@
 $workingDirectory = Get-Location
 $filePath = "$workingDirectory/tests.txt"
 
-$Tests = "<if(os_win)>../<example_files_win><else>../<example_files_unix><endif>"
-Write-Host "Test cases here: $Tests"
+Write-Host "Test cases: <glob_args_win>"
 
 # Get a list of test files from the test directory. Do not include any
 # .errors or .tree files. Pay close attention to remove only file names
@@ -14,7 +13,7 @@ if (Test-Path -Path "$filePath" -PathType Leaf) {
 }
 
 $files = New-Object System.Collections.Generic.List[string]
-$allFiles = $(& dotnet trash glob "$Tests" ; $last = $LASTEXITCODE )
+$allFiles = $(& dotnet trash glob <glob_args_win> ; $last = $LASTEXITCODE )
 foreach ($file in $allFiles) {
     $ext = $file | Split-Path -Extension
     if (Test-Path $file -PathType Container) {

--- a/src/trgen/templates/JavaScript/st.test.sh
+++ b/src/trgen/templates/JavaScript/st.test.sh
@@ -22,7 +22,7 @@ esac
 # Get a list of test files from the test directory. Do not include any
 # .errors or .tree files. Pay close attention to remove only file names
 # that end with the suffix .errors or .tree.
-files2=`dotnet trash glob '../<example_files_unix>' | tr -d '\r' | grep -v '[.]errors$' | grep -v '[.]tree$' | grep -v '[.]trq$'`
+files2=`dotnet trash glob <glob_args_unix> | tr -d '\r' | grep -v '[.]errors$' | grep -v '[.]tree$' | grep -v '[.]trq$'`
 files=()
 for f in $files2
 do

--- a/src/trgen/templates/OphiRust/st.perf.sh
+++ b/src/trgen/templates/OphiRust/st.perf.sh
@@ -56,7 +56,7 @@ echo "" >> parse.txt
 # Get a list of test files from the test directory. Do not include any
 # .errors or .tree files. Pay close attention to remove only file names
 # that end with the suffix .errors or .tree.
-files2=`dotnet trash glob '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
+files2=`dotnet trash glob <glob_args_unix> | grep -v '.errors$' | grep -v '.tree$'`
 files=()
 for f in $files2
 do

--- a/src/trgen/templates/OphiRust/st.test.ps1
+++ b/src/trgen/templates/OphiRust/st.test.ps1
@@ -3,8 +3,7 @@
 $workingDirectory = Get-Location
 $filePath = "$workingDirectory/tests.txt"
 
-$Tests = "<if(os_win)>../<example_files_win><else>../<example_files_unix><endif>"
-Write-Host "Test cases here: $Tests"
+Write-Host "Test cases: <glob_args_win>"
 
 # Get a list of test files from the test directory. Do not include any
 # .errors or .tree files. Pay close attention to remove only file names
@@ -14,7 +13,7 @@ if (Test-Path -Path "$filePath" -PathType Leaf) {
 }
 
 $files = New-Object System.Collections.Generic.List[string]
-$allFiles = $(& dotnet trash glob "$Tests" ; $last = $LASTEXITCODE )
+$allFiles = $(& dotnet trash glob <glob_args_win> ; $last = $LASTEXITCODE )
 foreach ($file in $allFiles) {
     $ext = $file | Split-Path -Extension
     if (Test-Path $file -PathType Container) {

--- a/src/trgen/templates/OphiRust/st.test.sh
+++ b/src/trgen/templates/OphiRust/st.test.sh
@@ -22,7 +22,7 @@ esac
 # Get a list of test files from the test directory. Do not include any
 # .errors or .tree files. Pay close attention to remove only file names
 # that end with the suffix .errors or .tree.
-files2=`dotnet trash glob '../<example_files_unix>' | tr -d '\r' | grep -v '[.]errors$' | grep -v '[.]tree$' | grep -v '[.]trq$'`
+files2=`dotnet trash glob <glob_args_unix> | tr -d '\r' | grep -v '[.]errors$' | grep -v '[.]tree$' | grep -v '[.]trq$'`
 files=()
 for f in $files2
 do

--- a/src/trgen/templates/PHP/st.perf.sh
+++ b/src/trgen/templates/PHP/st.perf.sh
@@ -56,7 +56,7 @@ echo "" >> parse.txt
 # Get a list of test files from the test directory. Do not include any
 # .errors or .tree files. Pay close attention to remove only file names
 # that end with the suffix .errors or .tree.
-files2=`dotnet trash glob '../<example_files_unix>' -type f | grep -v '.errors$' | grep -v '.tree$'`
+files2=`dotnet trash glob <glob_args_unix> | grep -v '.errors$' | grep -v '.tree$'`
 files=()
 for f in $files2
 do

--- a/src/trgen/templates/PHP/st.test.ps1
+++ b/src/trgen/templates/PHP/st.test.ps1
@@ -3,8 +3,7 @@
 $workingDirectory = Get-Location
 $filePath = "$workingDirectory/tests.txt"
 
-$Tests = "<if(os_win)>../<example_files_win><else>../<example_files_unix><endif>"
-Write-Host "Test cases here: $Tests"
+Write-Host "Test cases: <glob_args_win>"
 
 # Get a list of test files from the test directory. Do not include any
 # .errors or .tree files. Pay close attention to remove only file names
@@ -14,7 +13,7 @@ if (Test-Path -Path "$filePath" -PathType Leaf) {
 }
 
 $files = New-Object System.Collections.Generic.List[string]
-$allFiles = $(& dotnet trash glob "$Tests" ; $last = $LASTEXITCODE )
+$allFiles = $(& dotnet trash glob <glob_args_win> ; $last = $LASTEXITCODE )
 foreach ($file in $allFiles) {
     $ext = $file | Split-Path -Extension
     if (Test-Path $file -PathType Container) {

--- a/src/trgen/templates/PHP/st.test.sh
+++ b/src/trgen/templates/PHP/st.test.sh
@@ -22,7 +22,7 @@ esac
 # Get a list of test files from the test directory. Do not include any
 # .errors or .tree files. Pay close attention to remove only file names
 # that end with the suffix .errors or .tree.
-files2=`dotnet trash glob '../<example_files_unix>' | tr -d '\r' | grep -v '[.]errors$' | grep -v '[.]tree$' | grep -v '[.]trq$'`
+files2=`dotnet trash glob <glob_args_unix> | tr -d '\r' | grep -v '[.]errors$' | grep -v '[.]tree$' | grep -v '[.]trq$'`
 files=()
 for f in $files2
 do

--- a/src/trgen/templates/Python3/st.perf.sh
+++ b/src/trgen/templates/Python3/st.perf.sh
@@ -59,7 +59,7 @@ echo "" >> parse.txt
 # Get a list of test files from the test directory. Do not include any
 # .errors or .tree files. Pay close attention to remove only file names
 # that end with the suffix .errors or .tree.
-files2=`dotnet trash glob '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
+files2=`dotnet trash glob <glob_args_unix> | grep -v '.errors$' | grep -v '.tree$'`
 files=()
 for f in $files2
 do

--- a/src/trgen/templates/Python3/st.test.ps1
+++ b/src/trgen/templates/Python3/st.test.ps1
@@ -6,8 +6,7 @@ Get-Content test.ps1 | Write-Host
 $workingDirectory = Get-Location
 $filePath = "$workingDirectory/tests.txt"
 
-$Tests = "<if(os_win)>../<example_files_win><else>../<example_files_unix><endif>"
-Write-Host "Test cases here: $Tests"
+Write-Host "Test cases: <glob_args_win>"
 
 # Get a list of test files from the test directory. Do not include any
 # .errors or .tree files. Pay close attention to remove only file names
@@ -17,7 +16,7 @@ if (Test-Path -Path "$filePath" -PathType Leaf) {
 }
 
 $files = New-Object System.Collections.Generic.List[string]
-$allFiles = $(& dotnet trash glob "$Tests" ; $last = $LASTEXITCODE )
+$allFiles = $(& dotnet trash glob <glob_args_win> ; $last = $LASTEXITCODE )
 foreach ($file in $allFiles) {
     $ext = $file | Split-Path -Extension
     if (Test-Path $file -PathType Container) {

--- a/src/trgen/templates/Python3/st.test.sh
+++ b/src/trgen/templates/Python3/st.test.sh
@@ -25,7 +25,7 @@ esac
 # Get a list of test files from the test directory. Do not include any
 # .errors or .tree files. Pay close attention to remove only file names
 # that end with the suffix .errors or .tree.
-files2=`dotnet trash glob '../<example_files_unix>' | tr -d '\r' | grep -v '[.]errors$' | grep -v '[.]tree$' | grep -v '[.]trq$'`
+files2=`dotnet trash glob <glob_args_unix> | tr -d '\r' | grep -v '[.]errors$' | grep -v '[.]tree$' | grep -v '[.]trq$'`
 files=()
 for f in $files2
 do

--- a/src/trgen/templates/Rust/st.perf.sh
+++ b/src/trgen/templates/Rust/st.perf.sh
@@ -56,7 +56,7 @@ echo "" >> parse.txt
 # Get a list of test files from the test directory. Do not include any
 # .errors or .tree files. Pay close attention to remove only file names
 # that end with the suffix .errors or .tree.
-files2=`dotnet trash glob '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
+files2=`dotnet trash glob <glob_args_unix> | grep -v '.errors$' | grep -v '.tree$'`
 files=()
 for f in $files2
 do

--- a/src/trgen/templates/Rust/st.test.ps1
+++ b/src/trgen/templates/Rust/st.test.ps1
@@ -3,8 +3,7 @@
 $workingDirectory = Get-Location
 $filePath = "$workingDirectory/tests.txt"
 
-$Tests = "<if(os_win)>../<example_files_win><else>../<example_files_unix><endif>"
-Write-Host "Test cases here: $Tests"
+Write-Host "Test cases: <glob_args_win>"
 
 # Get a list of test files from the test directory. Do not include any
 # .errors or .tree files. Pay close attention to remove only file names
@@ -14,7 +13,7 @@ if (Test-Path -Path "$filePath" -PathType Leaf) {
 }
 
 $files = New-Object System.Collections.Generic.List[string]
-$allFiles = $(& dotnet trash glob "$Tests" ; $last = $LASTEXITCODE )
+$allFiles = $(& dotnet trash glob <glob_args_win> ; $last = $LASTEXITCODE )
 foreach ($file in $allFiles) {
     $ext = $file | Split-Path -Extension
     if (Test-Path $file -PathType Container) {

--- a/src/trgen/templates/Rust/st.test.sh
+++ b/src/trgen/templates/Rust/st.test.sh
@@ -22,7 +22,7 @@ esac
 # Get a list of test files from the test directory. Do not include any
 # .errors or .tree files. Pay close attention to remove only file names
 # that end with the suffix .errors or .tree.
-files2=`dotnet trash glob '../<example_files_unix>' | tr -d '\r' | grep -v '[.]errors$' | grep -v '[.]tree$' | grep -v '[.]trq$'`
+files2=`dotnet trash glob <glob_args_unix> | tr -d '\r' | grep -v '[.]errors$' | grep -v '[.]tree$' | grep -v '[.]trq$'`
 files=()
 for f in $files2
 do

--- a/src/trgen/templates/TypeScript/st.perf.sh
+++ b/src/trgen/templates/TypeScript/st.perf.sh
@@ -56,7 +56,7 @@ echo "" >> parse.txt
 # Get a list of test files from the test directory. Do not include any
 # .errors or .tree files. Pay close attention to remove only file names
 # that end with the suffix .errors or .tree.
-files2=`dotnet trash glob '../<example_files_unix>' | grep -v '.errors$' | grep -v '.tree$'`
+files2=`dotnet trash glob <glob_args_unix> | grep -v '.errors$' | grep -v '.tree$'`
 files=()
 for f in $files2
 do

--- a/src/trgen/templates/TypeScript/st.test.ps1
+++ b/src/trgen/templates/TypeScript/st.test.ps1
@@ -3,8 +3,7 @@
 $workingDirectory = Get-Location
 $filePath = "$workingDirectory/tests.txt"
 
-$Tests = "<if(os_win)>../<example_files_win><else>../<example_files_unix><endif>"
-Write-Host "Test cases here: $Tests"
+Write-Host "Test cases: <glob_args_win>"
 
 # Get a list of test files from the test directory. Do not include any
 # .errors or .tree files. Pay close attention to remove only file names
@@ -14,7 +13,7 @@ if (Test-Path -Path "$filePath" -PathType Leaf) {
 }
 
 $files = New-Object System.Collections.Generic.List[string]
-$allFiles = $(& dotnet trash glob "$Tests" ; $last = $LASTEXITCODE )
+$allFiles = $(& dotnet trash glob <glob_args_win> ; $last = $LASTEXITCODE )
 foreach ($file in $allFiles) {
     $ext = $file | Split-Path -Extension
     if (Test-Path $file -PathType Container) {

--- a/src/trgen/templates/TypeScript/st.test.sh
+++ b/src/trgen/templates/TypeScript/st.test.sh
@@ -22,7 +22,7 @@ esac
 # Get a list of test files from the test directory. Do not include any
 # .errors or .tree files. Pay close attention to remove only file names
 # that end with the suffix .errors or .tree.
-files2=`dotnet trash glob '../<example_files_unix>' | tr -d '\r' | grep -v '[.]errors$' | grep -v '[.]tree$' | grep -v '[.]trq$'`
+files2=`dotnet trash glob <glob_args_unix> | tr -d '\r' | grep -v '[.]errors$' | grep -v '[.]tree$' | grep -v '[.]trq$'`
 files=()
 for f in $files2
 do

--- a/src/trglob/Command.cs
+++ b/src/trglob/Command.cs
@@ -1,7 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text.RegularExpressions;
 
 namespace Trash;
 
@@ -53,12 +52,27 @@ class Command
 
         allFiles = allFiles.Distinct().ToList();
 
-        // Remove files whose path matches any negation pattern.
+        // Remove files matching any negation pattern, using GlobContents so that
+        // inclusion and exclusion share the same matching semantics (segment-aware,
+        // ** handling, separator normalisation, etc.).
         foreach (var negPat in negativePatterns)
         {
-            var regexStr = TrashGlobbing.Glob.GlobToRegex(negPat.Replace("\\", "/"));
-            var regex = new Regex(regexStr);
-            allFiles = allFiles.Where(f => !regex.IsMatch(f)).ToList();
+            var negGlob = new TrashGlobbing.Glob();
+            var z = negPat.Replace("\\", "/");
+            var negMatches = negGlob
+                .GlobContents(cwdi, z, true)
+                .Select(f =>
+                {
+                    var n = f.FullName.Replace('\\', '/');
+                    if (!config.Full)
+                    {
+                        var r = System.IO.Path.GetRelativePath(cwd, n);
+                        return r.Replace('\\', '/');
+                    }
+                    return n;
+                })
+                .ToHashSet();
+            allFiles = allFiles.Where(f => !negMatches.Contains(f)).ToList();
         }
 
         allFiles.Sort();

--- a/src/trglob/Command.cs
+++ b/src/trglob/Command.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
 
@@ -19,32 +20,51 @@ class Command
     {
         string cwd = System.Environment.CurrentDirectory;
         cwd = cwd.Replace("\\", "/");
-        if (!cwd.EndsWith("\\")) cwd += "/";
+        if (!cwd.EndsWith("/")) cwd += "/";
         DirectoryInfo cwdi = new DirectoryInfo(cwd);
-        foreach (var p in config.Files)
+
+        // Separate positive patterns from negation patterns (prefix '!').
+        var positivePatterns = config.Files.Where(p => !p.StartsWith("!")).ToList();
+        var negativePatterns = config.Files
+            .Where(p => p.StartsWith("!"))
+            .Select(p => p.Substring(1))
+            .ToList();
+
+        // Collect files from all positive patterns.
+        var allFiles = new List<string>();
+        foreach (var p in positivePatterns)
         {
             var glob = new TrashGlobbing.Glob();
             var z = p.Replace("\\", "/");
-            var list_pp = glob
+            var matches = glob
                 .GlobContents(cwdi, z, true)
                 .Select(f =>
                 {
                     var n = f.FullName.Replace('\\', '/');
-                    var r = n;
                     if (!config.Full)
                     {
-                        r = System.IO.Path.GetRelativePath(cwd, n);
-                        r = r.Replace('\\', '/');
+                        var r = System.IO.Path.GetRelativePath(cwd, n);
+                        return r.Replace('\\', '/');
                     }
-                    return r;
-                })
-                .ToList();
-            list_pp.Sort();
-            list_pp = list_pp.Distinct().ToList();
-            foreach (var y in list_pp)
-            {
-                System.Console.WriteLine(y);
-            }
+                    return n;
+                });
+            allFiles.AddRange(matches);
+        }
+
+        allFiles = allFiles.Distinct().ToList();
+
+        // Remove files whose path matches any negation pattern.
+        foreach (var negPat in negativePatterns)
+        {
+            var regexStr = TrashGlobbing.Glob.GlobToRegex(negPat.Replace("\\", "/"));
+            var regex = new Regex(regexStr);
+            allFiles = allFiles.Where(f => !regex.IsMatch(f)).ToList();
+        }
+
+        allFiles.Sort();
+        foreach (var y in allFiles)
+        {
+            System.Console.WriteLine(y);
         }
 
         return 0;


### PR DESCRIPTION
## Summary

- **TrashGlobbing**: `GlobToRegex` now supports `{a,b,c}` alternation patterns
- **trglob**: `Command.Execute` supports `!pattern` negation (gitignore-style) to exclude files from glob results
- **trgen**: reads all `<inputs>` elements from `desc.xml` instead of only the first; emits multi-argument `dotnet trash glob` calls (including negation patterns) via new `glob_args_unix` / `glob_args_win` template attributes
- All `st.test.sh`, `st.perf.sh`, `st.test-ambiguity.sh`, `st.test-cover.sh`, and `st.test.ps1` templates updated to use `<glob_args_unix>` / `<glob_args_win>` instead of a single `<example_files_*>` argument

## Test plan

- [ ] `dotnet build src/trglob/trglob.csproj` builds cleanly
- [ ] `dotnet build src/trgen/trgen.csproj` builds cleanly
- [ ] `trglob '*.cs' '!**/bin/**'` returns .cs files excluding bin directories
- [ ] `trglob '*.{sh,ps1}'` returns both .sh and .ps1 files
- [ ] Grammar with multiple `<inputs>` in `desc.xml` generates scripts that call `dotnet trash glob` with all patterns as separate arguments

🤖 Generated with [Claude Code](https://claude.com/claude-code)